### PR TITLE
Portfolio redesign + restored content + Intrapath + LA move

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,24 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Ala Arab</title>
+    <title>Ala Arab — Full-stack developer, Sacramento</title>
     <meta
       name="description"
-      content="Portfolio of Ala Arab, a full-stack developer in Sacramento building web products and internal tools."
+      content="Portfolio of Ala Arab. Full-stack developer in Sacramento building open-source tooling for AI agents, audio production, and ticket workflows, after a decade running an internal ERP at ADM Associates."
+    />
+    <link rel="canonical" href="https://alaarab.com/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://alaarab.com/" />
+    <meta property="og:title" content="Ala Arab — Full-stack developer, Sacramento" />
+    <meta
+      property="og:description"
+      content="Open-source tooling for AI agents, audio production, and ticket workflows. Previously a decade on the project-based ERP that became ADM Associates' system of record."
+    />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Ala Arab — Full-stack developer, Sacramento" />
+    <meta
+      name="twitter:description"
+      content="Open-source tooling for AI agents, audio production, and ticket workflows."
     />
     <link rel="icon" href="./public/favicon.ico" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
       content="Portfolio of Ala Arab. Full-stack developer in Sacramento building open-source tooling for AI agents, audio production, and ticket workflows, after a decade running an internal ERP at ADM Associates."
     />
     <link rel="canonical" href="https://alaarab.com/" />
+    <link rel="manifest" href="./public/manifest.webmanifest" />
+    <meta name="theme-color" content="#0f766e" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://alaarab.com/" />
     <meta property="og:title" content="Ala Arab — Full-stack developer, Sacramento" />

--- a/index.html
+++ b/index.html
@@ -3,23 +3,23 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Ala Arab — Full-stack developer, Sacramento</title>
+    <title>Ala Arab — Full-stack developer, Los Angeles</title>
     <meta
       name="description"
-      content="Portfolio of Ala Arab. Full-stack developer in Sacramento building open-source tooling for AI agents, audio production, and ticket workflows, after a decade running an internal ERP at ADM Associates."
+      content="Portfolio of Ala Arab. Full-stack developer in Los Angeles building open-source tooling for AI agents, audio production, and ticket workflows, after a decade running an internal ERP at ADM Associates."
     />
     <link rel="canonical" href="https://alaarab.com/" />
     <link rel="manifest" href="./public/manifest.webmanifest" />
-    <meta name="theme-color" content="#0f766e" />
+    <meta name="theme-color" content="#0e0c0a" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://alaarab.com/" />
-    <meta property="og:title" content="Ala Arab — Full-stack developer, Sacramento" />
+    <meta property="og:title" content="Ala Arab — Full-stack developer, Los Angeles" />
     <meta
       property="og:description"
       content="Open-source tooling for AI agents, audio production, and ticket workflows. Previously a decade on the project-based ERP that became ADM Associates' system of record."
     />
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="Ala Arab — Full-stack developer, Sacramento" />
+    <meta name="twitter:title" content="Ala Arab — Full-stack developer, Los Angeles" />
     <meta
       name="twitter:description"
       content="Open-source tooling for AI agents, audio production, and ticket workflows."
@@ -32,10 +32,10 @@
     <link
       rel="preload"
       as="style"
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=JetBrains+Mono:wght@400;500;700&display=swap"
     />
     <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=JetBrains+Mono:wght@400;500;700&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/index.html
+++ b/index.html
@@ -25,8 +25,15 @@
       content="Open-source tooling for AI agents, audio production, and ticket workflows."
     />
     <link rel="icon" href="./public/favicon.ico" />
+    <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
+    <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="preload"
+      as="style"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+    />
     <link
       href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;600;700&display=swap"
       rel="stylesheet"

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,16 @@
+{
+  "name": "Ala Arab",
+  "short_name": "Ala Arab",
+  "start_url": "/",
+  "display": "minimal-ui",
+  "background_color": "#f4efe7",
+  "theme_color": "#0f766e",
+  "description": "Portfolio of Ala Arab, full-stack developer in Sacramento.",
+  "icons": [
+    {
+      "src": "/favicon.ico",
+      "sizes": "32x32 64x64",
+      "type": "image/x-icon"
+    }
+  ]
+}

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -3,9 +3,9 @@
   "short_name": "Ala Arab",
   "start_url": "/",
   "display": "minimal-ui",
-  "background_color": "#f4efe7",
-  "theme_color": "#0f766e",
-  "description": "Portfolio of Ala Arab, full-stack developer in Sacramento.",
+  "background_color": "#0e0c0a",
+  "theme_color": "#0e0c0a",
+  "description": "Portfolio of Ala Arab, full-stack developer in Los Angeles.",
   "icons": [
     {
       "src": "/favicon.ico",

--- a/server.ts
+++ b/server.ts
@@ -1,13 +1,45 @@
 import index from "./index.html";
+import { projects } from "./src/data/siteContent";
 
 const isProd = process.env.NODE_ENV === "production";
+const SITE_ORIGIN = process.env.SITE_ORIGIN ?? "https://alaarab.com";
+
+function buildSitemap() {
+  const today = new Date().toISOString().slice(0, 10);
+  const urls = [
+    `${SITE_ORIGIN}/`,
+    `${SITE_ORIGIN}/projects`,
+    `${SITE_ORIGIN}/resume`,
+    ...projects.map((project) => `${SITE_ORIGIN}/projects/${project.slug}`),
+  ];
+  const body = urls
+    .map(
+      (loc) => `  <url><loc>${loc}</loc><lastmod>${today}</lastmod></url>`,
+    )
+    .join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${body}\n</urlset>\n`;
+}
+
+const ROBOTS_TXT = `User-agent: *
+Allow: /
+
+Sitemap: ${SITE_ORIGIN}/sitemap.xml
+`;
 
 const server = Bun.serve({
   port: Number(process.env.PORT ?? 3000),
   development: isProd ? false : { hmr: true, console: true },
-  // Every path resolves to the SPA shell. React Router takes it from there,
-  // so deep links like /projects/phren survive a hard refresh.
   routes: {
+    "/sitemap.xml": () =>
+      new Response(buildSitemap(), {
+        headers: { "content-type": "application/xml; charset=utf-8" },
+      }),
+    "/robots.txt": () =>
+      new Response(ROBOTS_TXT, {
+        headers: { "content-type": "text/plain; charset=utf-8" },
+      }),
+    // Every other path resolves to the SPA shell. React Router takes it from
+    // there, so deep links like /projects/phren survive a hard refresh.
     "/*": index,
   },
 });

--- a/server.ts
+++ b/server.ts
@@ -10,6 +10,7 @@ function buildSitemap() {
     `${SITE_ORIGIN}/`,
     `${SITE_ORIGIN}/projects`,
     `${SITE_ORIGIN}/resume`,
+    `${SITE_ORIGIN}/now`,
     ...projects.map((project) => `${SITE_ORIGIN}/projects/${project.slug}`),
   ];
   const body = urls

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Route, Routes } from "react-router";
 import { ScrollToTop } from "./components/ScrollToTop";
 import { Home } from "./pages/Home";
 import { NotFound } from "./pages/NotFound";
+import { Now } from "./pages/Now";
 import { ProjectDetail } from "./pages/ProjectDetail";
 import { Projects } from "./pages/Projects";
 import { Resume } from "./pages/Resume";
@@ -13,6 +14,7 @@ export function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/resume" element={<Resume />} />
+        <Route path="/now" element={<Now />} />
         <Route path="/projects" element={<Projects />} />
         <Route path="/projects/:slug" element={<ProjectDetail />} />
         <Route path="*" element={<NotFound />} />

--- a/src/components/ActionLinks.tsx
+++ b/src/components/ActionLinks.tsx
@@ -28,7 +28,10 @@ export function ActionLinks({ links, className }: ActionLinksProps) {
             key={link.label}
             href={link.href}
             target={external ? "_blank" : undefined}
-            rel={external ? "noreferrer" : undefined}
+            rel={external ? "noreferrer noopener" : undefined}
+            aria-label={
+              external ? `${link.label} (opens in a new tab)` : undefined
+            }
           >
             {link.label}
           </a>

--- a/src/data/siteContent.ts
+++ b/src/data/siteContent.ts
@@ -19,8 +19,7 @@ export const siteMeta: SiteMeta = {
   email: "alaarab@gmail.com",
   emailHref: "mailto:alaarab@gmail.com",
   linkedinHref: "https://www.linkedin.com/in/ala-arab-a995b155/",
-  availability:
-    "Available for product work, internal tooling, and selected consulting.",
+  availability: "Open to selected consulting.",
 };
 
 export const quickStats: QuickStat[] = [
@@ -308,6 +307,14 @@ export const nowMeta = {
 
 export const nowItems: NowItem[] = [
   {
+    heading: "Systems Software Architect at Qualus Corp",
+    body: "Day job. Architecting internal software systems across the engineering org.",
+  },
+  {
+    heading: "Rebuilding the ERP from scratch",
+    body: "Personal rewrite of the project-based ERP I built and ran at ADM for a decade. Same problem space, fresh stack, no legacy baggage.",
+  },
+  {
     heading: "Shipping Phren past the prototype",
     body: "Memory layer for coding agents. Getting the retrieval ranker to a place where I'd trust it on my own repos before pitching it to anyone else.",
   },
@@ -315,20 +322,24 @@ export const nowItems: NowItem[] = [
     heading: "Music tooling for myself first",
     body: "LiveMCP and m4l-builder both started because I wanted them. Continuing in that spirit — only adding features I'd actually use in a session.",
   },
-  {
-    heading: "Looking for the next thing",
-    body: "Open to staff/principal full-stack roles where the team is small enough that I'd own real surface area. Bay Area, Sacramento, or remote.",
-  },
 ];
 
 export const experienceItems: ExperienceItem[] = [
   {
+    company: "Qualus Corp",
+    role: "Systems Software Architect",
+    years: "2025 to present",
+    location: "Sacramento, CA",
+    summary:
+      "Architecting internal software systems across the engineering org.",
+  },
+  {
     company: "ADM Associates, Inc.",
-    role: "Software Engineer",
+    role: "IT Engineer, then Systems Software Engineer",
     years: "2012 to 2025",
     location: "Sacramento, CA",
     summary:
-      "Thirteen years here, most of it building Intranet, the project-based ERP that became the company's primary system and replaced Deltek Vision. Helped grow the software engineering team, stood up CI/CD on GitHub Actions, and ran SOC 2-compliant Linux servers and on-prem infrastructure alongside the MongoDB, PostgreSQL, MySQL, and MS SQL databases behind it.",
+      "Thirteen years here, starting in IT and moving into systems software. Built Intranet, the project-based ERP that became the company's primary system and replaced Deltek Vision. Helped grow the software engineering team, stood up CI/CD on GitHub Actions, and ran SOC 2-compliant Linux servers and on-prem infrastructure alongside the MongoDB, PostgreSQL, MySQL, and MS SQL databases behind it.",
   },
   {
     company: "Greater Sacramento Pediatrics Association",

--- a/src/data/siteContent.ts
+++ b/src/data/siteContent.ts
@@ -15,7 +15,7 @@ export const siteMeta: SiteMeta = {
     "I like software that is honest about what it does and stays that way once the demo is over.",
   summary:
     "Most of what I ship now is open source: persistent memory for AI agents, headless spreadsheet hooks, a Python toolchain for Max for Live, an MCP bridge for Ableton, and a local-first ticket explorer. Before that, thirteen years building an internal ERP that became the system of record for a consulting firm and a licensed product on the side.",
-  location: "Sacramento, California",
+  location: "Los Angeles, California",
   email: "alaarab@gmail.com",
   emailHref: "mailto:alaarab@gmail.com",
   linkedinHref: "https://www.linkedin.com/in/ala-arab-a995b155/",
@@ -23,7 +23,7 @@ export const siteMeta: SiteMeta = {
 };
 
 export const quickStats: QuickStat[] = [
-  { label: "Based in", value: "Sacramento, CA" },
+  { label: "Based in", value: "Los Angeles, CA" },
   { label: "Focus", value: "Web products and internal tools" },
   { label: "Approach", value: "Honest, reliable, useful past demo day" },
 ];
@@ -329,7 +329,7 @@ export const experienceItems: ExperienceItem[] = [
     company: "Qualus Corp",
     role: "Systems Software Architect",
     years: "2025 to present",
-    location: "Sacramento, CA",
+    location: "Los Angeles, CA",
     summary:
       "Architecting internal software systems across the engineering org.",
   },

--- a/src/data/siteContent.ts
+++ b/src/data/siteContent.ts
@@ -54,6 +54,7 @@ export const projects: Project[] = [
       "Claude / Copilot / Cursor / Codex",
     ],
     thread: "Agent tooling",
+    quote: "Your agents forget everything. Phren doesn't.",
     links: [
       { label: "Project page", href: "/projects/phren" },
       { label: "GitHub", href: "https://github.com/alaarab/phren" },
@@ -85,6 +86,8 @@ export const projects: Project[] = [
       "Sigstore + SBOM releases",
     ],
     thread: "Agent tooling",
+    quote:
+      "Halo's web UI, but you live in your editor. Files are real Markdown, your editor gets a folder, your AI gets a corpus.",
     links: [
       { label: "Project page", href: "/projects/halo-explorer" },
       { label: "GitHub", href: "https://github.com/alaarab/halo" },
@@ -145,6 +148,8 @@ export const projects: Project[] = [
       "Reverse-engineering pipeline",
     ],
     thread: "Music tooling",
+    quote:
+      "Write scripts, emit .amxd files straight to your Ableton User Library. No Max GUI required.",
     links: [
       { label: "Project page", href: "/projects/m4l-builder" },
       { label: "GitHub", href: "https://github.com/alaarab/m4l-builder" },
@@ -176,6 +181,8 @@ export const projects: Project[] = [
       "macOS / Windows / WSL",
     ],
     thread: "Music tooling",
+    quote:
+      "Tools are for actions. Resources are for inspection. LiveMCP turns Ableton Live into an MCP-accessible control surface.",
     links: [
       { label: "Project page", href: "/projects/livemcp" },
       { label: "GitHub", href: "https://github.com/alaarab/livemcp" },

--- a/src/data/siteContent.ts
+++ b/src/data/siteContent.ts
@@ -249,16 +249,16 @@ export const projects: Project[] = [
     status: "Shipped",
     year: "2011",
     summary:
-      "A web interface for live sensor data used by a learning center.",
+      "A web interface for a learning-center garden wired up with light, temperature, and moisture sensors. Built at UCSD with a cross-discipline engineering team.",
     outcome:
-      "Turned raw readings into something non-technical users could act on.",
+      "Sensor data became something the Learning Center staff could actually read — and use to decide how to take care of their plants.",
     problem:
-      "The team needed a clearer view of light, temperature, and moisture data.",
+      "Sensors were streaming readings as JSON, but no one at the center had a way to see them in context.",
     build:
-      "I designed and built a page that surfaced incoming JSON sensor data in a usable way.",
+      "Designed and implemented the web UI on top of the incoming JSON stream. Collaborated with computer science, electrical, and mechanical engineers on the surrounding hardware-software stack, and extended a Processing-based UCSD Music Video Game in the same program.",
     impact:
-      "It was an early example of a pattern I still value: making technical information useful to real people.",
-    stack: ["JSON", "Web UI", "Sensor data"],
+      "An early example of a pattern I still value: take technical readings and make them useful to real people. Built as part of UCSD TIES at the Town and Country Learning Center.",
+    stack: ["JSON", "Web UI", "Processing", "Sensor data"],
     links: [{ label: "Project page", href: "/projects/garden-sensor-network" }],
     featured: false,
   },
@@ -269,16 +269,16 @@ export const projects: Project[] = [
     status: "Shipped",
     year: "2012 to 2013",
     summary:
-      "Workflow applications and migration tooling for retrofit program operations.",
+      "Web applications, iPad data-entry tools, and migration tooling for a retrofit program based in Maryland. Built at Matrix Energy Services.",
     outcome:
-      "Helped move data between systems and supported field and program workflows.",
+      "Field crews could capture and move data between disconnected systems without exporting through Excel by hand.",
     problem:
-      "Teams needed practical software around disconnected systems and messy operational workflows.",
+      "The retrofit program ran on a mix of legacy systems and spreadsheets, with no clean path from the field back into the database.",
     build:
-      "I built migration tools, supported testing, and contributed to the surrounding web application work.",
+      "Led web application development alongside the project managers. Built iPad apps for field capture, Ruby on Rails services on the backend, and Excel-based migrators for the data already in flight. Wrote and ran the test procedures, and redeveloped the company website in the same window.",
     impact:
-      "The result was better operational flow without pretending the environment was clean or simple.",
-    stack: ["Ruby on Rails", "Excel", "iPad workflows", "Web applications"],
+      "Cleaner operational flow without pretending the environment was clean or simple — the same instinct that later became Intranet at ADM.",
+    stack: ["Ruby on Rails", "iPad apps", "Excel", "Web applications"],
     links: [
       { label: "Project page", href: "/projects/retrofit-program-data-tools" },
     ],
@@ -347,7 +347,7 @@ export const experienceItems: ExperienceItem[] = [
     years: "2019",
     location: "Sacramento, CA",
     summary:
-      "Improved support processes and handled domain and email migration to Office 365.",
+      "Proposed and implemented system enhancements while documenting existing and new processes for the IT support team. Migrated the domain and email to Office 365 and ran the server fleet in a VMware environment.",
   },
   {
     company: "Matrix Energy Services, Inc.",
@@ -355,22 +355,30 @@ export const experienceItems: ExperienceItem[] = [
     years: "2012 to 2013",
     location: "Sacramento, CA",
     summary:
-      "Built tools for retrofit programs, moved data between systems, and supported delivery work.",
+      "Worked alongside project managers to lead web application development for a retrofit program in Maryland. Built iPad apps, Ruby on Rails services, and Excel-based tooling for migrating data between systems and databases. Wrote and ran the test procedures, and redeveloped the company website.",
   },
   {
-    company: "UC San Diego TIES",
-    role: "Developer",
+    company: "UC San Diego TIES — Town and Country Learning Center",
+    role: "Computer Science Developer",
     years: "2011",
     location: "San Diego, CA",
     summary:
-      "Built educational web interfaces around sensor data and collaborative learning-center projects.",
+      "Designed and built the web interface for a Garden Sensor Network that turned incoming JSON sensor readings — light, temperature, moisture — into something the Learning Center could actually act on. Also extended a UCSD Music Video Game written in Processing. Worked across CS, electrical, and mechanical engineering teams to bring inventive ideas into the center.",
+  },
+  {
+    company: "Dell",
+    role: "Campus Marketing, Advertising, and Technical Support",
+    years: "2008 to 2009",
+    location: "Santa Cruz, CA",
+    summary:
+      "Dell's on-campus presence at UC Santa Cruz. Provided technical support to students and parents on the Dell product line with a sales goal, and ran on-campus marketing strategies with a partner.",
   },
 ];
 
 export const educationItems: EducationItem[] = [
   {
     school: "University of California, San Diego",
-    detail: "B.S. in Computer Science",
+    detail: "B.S. in Computer Science · graduated December 2011",
     years: "2008 to 2011",
   },
   {

--- a/src/data/siteContent.ts
+++ b/src/data/siteContent.ts
@@ -308,11 +308,11 @@ export const nowMeta = {
 export const nowItems: NowItem[] = [
   {
     heading: "Systems Software Architect at Qualus Corp",
-    body: "Day job. Architecting internal software systems across the engineering org.",
+    body: "Day job. Database management systems for client portfolios, plus the internal tools that move data across the company — CRM through APIs into Power BI and Tableau. Lots of Node, React, and Angular.",
   },
   {
     heading: "Rebuilding the ERP from scratch",
-    body: "Personal rewrite of the project-based ERP I built and ran at ADM for a decade. Same problem space, fresh stack, no legacy baggage.",
+    body: "Personal rewrite of the project-based ERP I built and ran at ADM for a decade. The original was Ruby on Rails over ten-plus years; this one's React on Bun, built around a better take on how project management and workflow actually want to be modeled.",
   },
   {
     heading: "Shipping Phren past the prototype",
@@ -320,7 +320,7 @@ export const nowItems: NowItem[] = [
   },
   {
     heading: "Music tooling for myself first",
-    body: "LiveMCP and m4l-builder both started because I wanted them. Continuing in that spirit — only adding features I'd actually use in a session.",
+    body: "I produce electronic music in Ableton, and got tired of waiting for the tools to exist. LiveMCP and m4l-builder both started that way. Continuing in that spirit — only features I'd actually use in a session.",
   },
 ];
 
@@ -331,7 +331,7 @@ export const experienceItems: ExperienceItem[] = [
     years: "2025 to present",
     location: "Los Angeles, CA",
     summary:
-      "Architecting internal software systems across the engineering org.",
+      "Architecting database management systems for client portfolios, plus the internal tools and automation that move data across the company — CRM through APIs into Power BI and Tableau reporting. Stack is Node, React, and Angular sitting on top of the databases.",
   },
   {
     company: "ADM Associates, Inc.",
@@ -339,7 +339,7 @@ export const experienceItems: ExperienceItem[] = [
     years: "2012 to 2025",
     location: "Sacramento, CA",
     summary:
-      "Thirteen years here, starting in IT and moving into systems software. Built Intranet, the project-based ERP that became the company's primary system and replaced Deltek Vision. Helped grow the software engineering team, stood up CI/CD on GitHub Actions, and ran SOC 2-compliant Linux servers and on-prem infrastructure alongside the MongoDB, PostgreSQL, MySQL, and MS SQL databases behind it.",
+      "Thirteen years, starting in IT and moving into systems software. Built and ran a stack of internal apps — Intranet (the project-based ERP that replaced Deltek Vision, on PostgreSQL + Rails), EMV (MongoDB), an Equipment Tracker (PostgreSQL + Node) — and most of the company's web presence. Stood up the data science infrastructure so analysts could deploy R workloads to R Server and ship Shiny apps. Ran the Linux fleet, the multi-database backend (MongoDB, PostgreSQL, MySQL, MS SQL), and the SOC 2 environment underneath all of it. Helped grow the engineering team and stood up CI/CD on GitHub Actions.",
   },
   {
     company: "Greater Sacramento Pediatrics Association",

--- a/src/data/siteContent.ts
+++ b/src/data/siteContent.ts
@@ -53,6 +53,7 @@ export const projects: Project[] = [
       "FTS5 + semantic fallback",
       "Claude / Copilot / Cursor / Codex",
     ],
+    thread: "Agent tooling",
     links: [
       { label: "Project page", href: "/projects/phren" },
       { label: "GitHub", href: "https://github.com/alaarab/phren" },
@@ -83,6 +84,7 @@ export const projects: Project[] = [
       "Loopback-only, read-only allowlist",
       "Sigstore + SBOM releases",
     ],
+    thread: "Agent tooling",
     links: [
       { label: "Project page", href: "/projects/halo-explorer" },
       { label: "GitHub", href: "https://github.com/alaarab/halo" },
@@ -142,6 +144,7 @@ export const projects: Project[] = [
       "880+ tests",
       "Reverse-engineering pipeline",
     ],
+    thread: "Music tooling",
     links: [
       { label: "Project page", href: "/projects/m4l-builder" },
       { label: "GitHub", href: "https://github.com/alaarab/m4l-builder" },
@@ -172,6 +175,7 @@ export const projects: Project[] = [
       "Tools + live:// / max:// / docs:// resources",
       "macOS / Windows / WSL",
     ],
+    thread: "Music tooling",
     links: [
       { label: "Project page", href: "/projects/livemcp" },
       { label: "GitHub", href: "https://github.com/alaarab/livemcp" },

--- a/src/data/siteContent.ts
+++ b/src/data/siteContent.ts
@@ -30,6 +30,32 @@ export const quickStats: QuickStat[] = [
 
 export const projects: Project[] = [
   {
+    slug: "intrapath",
+    accent: "#f43f5e",
+    title: "Intrapath",
+    category: "Current",
+    status: "In active development",
+    year: "2026",
+    summary:
+      "Personal rewrite of the project-based ERP I built and ran at ADM for a decade. React on Bun this time, with a better take on how project management and workflow want to be modeled.",
+    outcome:
+      "An ERP that's actually conducive to project management and workflow — not a system that survived because everyone learned to work around it.",
+    problem:
+      "After ten-plus years running the original Intranet on Ruby on Rails, I learned a lot about what fit a project-based business and what was a compromise that calcified. Time to start fresh, with the workflow modeled right from the data layer up.",
+    build:
+      "React on Bun. Rebuilding the data model and workflow primitives from scratch, with a stronger handle on how project-based organizational styles actually want to be modeled — not bending an existing CRM or PM tool to fit.",
+    impact:
+      "Active development. No public release yet.",
+    stack: ["React", "Bun", "TypeScript"],
+    metrics: [
+      "Successor to Intranet",
+      "React + Bun",
+      "Workflow-first data model",
+    ],
+    links: [{ label: "Project page", href: "/projects/intrapath" }],
+    featured: true,
+  },
+  {
     slug: "phren",
     accent: "#7c3aed",
     title: "Phren",
@@ -212,6 +238,48 @@ export const projects: Project[] = [
     ],
     links: [{ label: "Project page", href: "/projects/intranet-erp" }],
     featured: true,
+  },
+  {
+    slug: "emv",
+    accent: "#84cc16",
+    title: "EMV",
+    category: "Legacy case study",
+    status: "Shipped at ADM",
+    year: "2014 to 2025",
+    summary:
+      "An internal MongoDB-backed app built at ADM Associates for a workflow that fit a document store better than a relational one. Sister system to Intranet.",
+    outcome:
+      "Filled a slice of the company's internal toolkit that Intranet wasn't the right shape for.",
+    problem:
+      "Not every workflow at ADM mapped cleanly into the relational data model behind Intranet — some wanted to be modeled as documents.",
+    build:
+      "Node.js on MongoDB.",
+    impact:
+      "Ran internally at ADM as one of the apps that made up the day-to-day software stack.",
+    stack: ["MongoDB", "Node.js"],
+    links: [{ label: "Project page", href: "/projects/emv" }],
+    featured: false,
+  },
+  {
+    slug: "equipment-tracker",
+    accent: "#06b6d4",
+    title: "Equipment Tracker",
+    category: "Legacy case study",
+    status: "Shipped at ADM",
+    year: "2018 to 2025",
+    summary:
+      "An internal app for tracking equipment, on PostgreSQL and Node. Built at ADM Associates as part of the operations toolkit alongside Intranet.",
+    outcome:
+      "Equipment records lived in one place instead of across spreadsheets and people's heads.",
+    problem:
+      "Field and lab equipment got tracked in whatever the previous owner happened to be using, which was usually a spreadsheet.",
+    build:
+      "Node service on PostgreSQL with an internal UI for the operations side.",
+    impact:
+      "Used across the operations side of the company as part of the broader app suite.",
+    stack: ["PostgreSQL", "Node.js"],
+    links: [{ label: "Project page", href: "/projects/equipment-tracker" }],
+    featured: false,
   },
   {
     slug: "alphalens",

--- a/src/data/siteContent.ts
+++ b/src/data/siteContent.ts
@@ -291,6 +291,36 @@ export const featuredProjects: Project[] = projects.filter(
   (project) => project.featured,
 );
 
+export type NowItem = {
+  heading: string;
+  body: string;
+};
+
+/**
+ * What I'm focused on this season — a /now page in the spirit of
+ * nownownow.com. Refresh whenever the focus actually shifts.
+ */
+export const nowMeta = {
+  asOf: "May 2026",
+  intro:
+    "A snapshot of what I'm actually spending hours on right now. Lighter than a roadmap, more honest than a Twitter bio.",
+};
+
+export const nowItems: NowItem[] = [
+  {
+    heading: "Shipping Phren past the prototype",
+    body: "Memory layer for coding agents. Getting the retrieval ranker to a place where I'd trust it on my own repos before pitching it to anyone else.",
+  },
+  {
+    heading: "Music tooling for myself first",
+    body: "LiveMCP and m4l-builder both started because I wanted them. Continuing in that spirit — only adding features I'd actually use in a session.",
+  },
+  {
+    heading: "Looking for the next thing",
+    body: "Open to staff/principal full-stack roles where the team is small enough that I'd own real surface area. Bay Area, Sacramento, or remote.",
+  },
+];
+
 export const experienceItems: ExperienceItem[] = [
   {
     company: "ADM Associates, Inc.",

--- a/src/data/siteContent.ts
+++ b/src/data/siteContent.ts
@@ -10,10 +10,11 @@ import type {
 export const siteMeta: SiteMeta = {
   name: "Ala Arab",
   title:
-    "Full-stack developer building useful web products and internal tools.",
-  intro: "I build software that is clear, reliable, and practical.",
+    "Full-stack developer building web products and the unglamorous tools that keep them running.",
+  intro:
+    "I like software that is honest about what it does and stays that way once the demo is over.",
   summary:
-    "My background spans product-minded frontend work, backend systems, and the operational layer around shipping software well.",
+    "Most of what I ship now is open source: persistent memory for AI agents, headless spreadsheet hooks, a Python toolchain for Max for Live, an MCP bridge for Ableton, and a local-first ticket explorer. Before that, thirteen years building an internal ERP that became the system of record for a consulting firm and a licensed product on the side.",
   location: "Sacramento, California",
   email: "alaarab@gmail.com",
   emailHref: "mailto:alaarab@gmail.com",
@@ -25,30 +26,10 @@ export const siteMeta: SiteMeta = {
 export const quickStats: QuickStat[] = [
   { label: "Based in", value: "Sacramento, CA" },
   { label: "Focus", value: "Web products and internal tools" },
-  { label: "Approach", value: "Clear, reliable, practical" },
+  { label: "Approach", value: "Honest, reliable, useful past demo day" },
 ];
 
 export const projects: Project[] = [
-  {
-    slug: "portfolio-refresh",
-    title: "Portfolio Refresh",
-    category: "Current",
-    status: "In progress",
-    year: "2026",
-    summary: "A rebuild of this site into a cleaner, project-led portfolio.",
-    outcome:
-      "A shorter structure, cleaner visual system, and a better place to add real project work.",
-    problem: "The old site felt dated and made it awkward to add new work.",
-    build:
-      "I rebuilt it around concise sections, reusable project data, and simple case-study pages.",
-    impact: "The portfolio now feels current and is easier to maintain.",
-    stack: ["Bun", "React", "TypeScript", "Content-first structure"],
-    links: [
-      { label: "Project page", href: "/projects/portfolio-refresh" },
-      { label: "Resume page", href: "/resume" },
-    ],
-    featured: true,
-  },
   {
     slug: "phren",
     accent: "#7c3aed",
@@ -67,10 +48,44 @@ export const projects: Project[] = [
     impact:
       "It works across Claude, Copilot, Cursor, and Codex, and reloads cleanly on a new machine with a single init command.",
     stack: ["TypeScript", "MCP", "Turborepo", "Node.js"],
+    metrics: [
+      "54 MCP tools",
+      "FTS5 + semantic fallback",
+      "Claude / Copilot / Cursor / Codex",
+    ],
     links: [
       { label: "Project page", href: "/projects/phren" },
       { label: "GitHub", href: "https://github.com/alaarab/phren" },
       { label: "Docs", href: "https://alaarab.github.io/phren/" },
+    ],
+    featured: true,
+  },
+  {
+    slug: "halo-explorer",
+    accent: "#2ab8a8",
+    title: "Halo Explorer",
+    category: "Open source",
+    status: "Stable",
+    year: "2026",
+    summary:
+      "Halo's web UI, but you live in your editor. A local-first CLI and four-view desktop app that pulls every ticket onto disk as markdown, then exposes them to any AI tool through MCP.",
+    outcome:
+      "Tickets become a corpus your editor and your agents can both read. The browser tab strip stops eating your context.",
+    problem:
+      "Halo only ships a SPA. Forty open tickets, filters that reset on reload, no way to grep, and nothing an AI tool can investigate without a half-dozen round trips.",
+    build:
+      "Bun + Hono server, no-bundler ES module frontend, force-directed D3 graph, MCP server with one fan-out tool that returns a full investigation envelope. Loopback-only with a read-only allowlist on the upstream API.",
+    impact:
+      "Stable since 1.0.0 with a sigstore-signed release pipeline, CycloneDX SBOM, CodeQL, a smell-check workflow that blocks writes outside the allowlist, and an operational /health endpoint.",
+    stack: ["Bun", "Hono", "D3", "MCP", "Biome"],
+    metrics: [
+      "14 typed MCP tools",
+      "Loopback-only, read-only allowlist",
+      "Sigstore + SBOM releases",
+    ],
+    links: [
+      { label: "Project page", href: "/projects/halo-explorer" },
+      { label: "GitHub", href: "https://github.com/alaarab/halo" },
     ],
     featured: true,
   },
@@ -92,6 +107,11 @@ export const projects: Project[] = [
     impact:
       "It ships as MIT-licensed npm packages with documentation and an AG Grid migration guide.",
     stack: ["React", "TypeScript", "Headless UI", "npm"],
+    metrics: [
+      "Headless hooks",
+      "Drops onto shadcn / Material / Fluent",
+      "MIT licensed",
+    ],
     links: [
       { label: "Project page", href: "/projects/ogrid" },
       { label: "GitHub", href: "https://github.com/alaarab/ogrid" },
@@ -107,22 +127,110 @@ export const projects: Project[] = [
     status: "Active",
     year: "2026",
     summary:
-      "A Python library for building Max for Live (.amxd) devices in code, no Max GUI required.",
+      "Max for Live devices written in Python instead of clicked together in a GUI. Pure standard library, ships to PyPI.",
     outcome:
       "Audio devices become scriptable, reproducible, and version-controllable instead of being trapped in a visual editor.",
     problem:
       "Building Max for Live devices means clicking around a GUI, which makes the work hard to version, review, or reproduce.",
     build:
-      "I built a pure-stdlib Python library that emits valid .amxd files, with modules for UI, DSP, jsui visual engines, and a theme system.",
+      "Pure-stdlib Python library that emits valid .amxd files: 90+ DSP blocks, a theme system, jsui visual engines, a recipe layer for common combos, and a reverse-engineering pipeline that reads existing devices back into Python.",
     impact:
-      "It ships on PyPI with 880+ tests and a set of example plugins covering filters, compressors, delays, and saturation.",
+      "Ships on PyPI with a test suite that asserts the produced .amxd files actually load in Ableton, and a corpus-mining toolchain that turns external devices into structured fixture data.",
     stack: ["Python", "Max for Live", "Audio DSP", "PyPI"],
+    metrics: [
+      "90+ DSP blocks",
+      "880+ tests",
+      "Reverse-engineering pipeline",
+    ],
     links: [
       { label: "Project page", href: "/projects/m4l-builder" },
       { label: "GitHub", href: "https://github.com/alaarab/m4l-builder" },
       { label: "PyPI", href: "https://pypi.org/project/m4l-builder/" },
     ],
     featured: true,
+  },
+  {
+    slug: "livemcp",
+    accent: "#0ea5e9",
+    title: "LiveMCP",
+    category: "Open source",
+    status: "Active",
+    year: "2026",
+    summary:
+      "An MCP bridge for Ableton Live. Controller-first interface for transport, views, tracks, clips, devices, and the mixer, plus stable read resources for current state.",
+    outcome:
+      "An agent can investigate a Live set or drive a session without the operator clicking through Ableton's UI.",
+    problem:
+      "Ableton's Live API is reachable from Python but stitching together the right calls for even simple controller tasks is a project in itself.",
+    build:
+      "Python FastMCP server talking to a bundled MIDI Remote Script over a local TCP bridge, with a second bridge into Max for Live patcher internals. Read/write split keeps Live from being mutated off the main thread.",
+    impact:
+      "Runs on macOS, Windows, and WSL, ships with packaged install/restart helpers, and includes an offline local-docs sync for Ableton and Cycling '74 references.",
+    stack: ["Python", "MCP", "Ableton Live", "FastMCP"],
+    metrics: [
+      "220 tools",
+      "Tools + live:// / max:// / docs:// resources",
+      "macOS / Windows / WSL",
+    ],
+    links: [
+      { label: "Project page", href: "/projects/livemcp" },
+      { label: "GitHub", href: "https://github.com/alaarab/livemcp" },
+    ],
+    featured: true,
+  },
+  {
+    slug: "intranet-erp",
+    title: "Intranet ERP",
+    category: "Flagship product",
+    status: "Primary company ERP for a decade",
+    year: "2013 to 2023",
+    summary:
+      "The project-based ERP I built and grew into ADM Associates' system of record, then licensed to outside clients.",
+    outcome:
+      "One platform for project management, budgeting, accounting, and workflows that replaced Deltek Vision across the company.",
+    problem:
+      "The company ran on Deltek Vision and a legacy VB.NET application that never fit how a project-based consulting firm actually works.",
+    build:
+      "I started Intranet shortly after joining and owned it for the next ten years as it grew from a small app into a full ERP. The engineering team, the CI/CD pipeline, and the infrastructure all grew up around it.",
+    impact:
+      "It became the primary ERP of the company and a product in its own right, run internally and sold to clients.",
+    stack: ["Ruby on Rails", "PostgreSQL", "MS SQL", "Docker", "GitHub Actions"],
+    metrics: [
+      "~82 tables, ~50 controllers",
+      "Replaced Deltek Vision company-wide",
+      "Licensed to outside clients",
+    ],
+    links: [{ label: "Project page", href: "/projects/intranet-erp" }],
+    featured: true,
+  },
+  {
+    slug: "alphalens",
+    accent: "#f59e0b",
+    title: "AlphaLens",
+    category: "Open source",
+    status: "Shipped",
+    year: "2025",
+    summary:
+      "A Discord bot for real-time crypto charts, contract lookups, and trending-token alerts across nine networks.",
+    outcome:
+      "Trading servers get the chart and contract context they want inline, without leaving Discord.",
+    problem:
+      "Existing bots either lock features behind subscriptions or stop short of the cross-network coverage active trading rooms actually use.",
+    build:
+      "Node.js bot with slash commands, encrypted per-server settings storage, rotating API keys for the upstream provider, and a monitoring loop that posts trending-token alerts to a watched channel.",
+    impact:
+      "Runs on PM2 in production, MIT licensed, and covers Solana, Ethereum, BSC, Avalanche, Fantom, Base, Berachain, Sui, and Monad.",
+    stack: ["Node.js", "Discord.js", "AES-256", "PM2"],
+    metrics: [
+      "9 networks",
+      "Encrypted per-server settings",
+      "PM2 in production",
+    ],
+    links: [
+      { label: "Project page", href: "/projects/alphalens" },
+      { label: "GitHub", href: "https://github.com/alaarab/AlphaLens" },
+    ],
+    featured: false,
   },
   {
     slug: "garden-sensor-network",
@@ -165,26 +273,6 @@ export const projects: Project[] = [
       { label: "Project page", href: "/projects/retrofit-program-data-tools" },
     ],
     featured: false,
-  },
-  {
-    slug: "intranet-erp",
-    title: "Intranet ERP",
-    category: "Flagship product",
-    status: "Primary company ERP for a decade",
-    year: "2013 to 2023",
-    summary:
-      "The project-based ERP I built and grew into ADM Associates' system of record, then licensed to outside clients.",
-    outcome:
-      "One platform for project management, budgeting, accounting, and workflows that replaced Deltek Vision across the company.",
-    problem:
-      "The company ran on Deltek Vision and a legacy VB.NET application that never fit how a project-based consulting firm actually works.",
-    build:
-      "I started Intranet shortly after joining and owned it for the next ten years as it grew from a small app into a full ERP. The engineering team, the CI/CD pipeline, and the infrastructure all grew up around it.",
-    impact:
-      "It became the primary ERP of the company and a product in its own right, run internally and sold to clients.",
-    stack: ["Ruby on Rails", "PostgreSQL", "MS SQL", "Docker", "GitHub Actions"],
-    links: [{ label: "Project page", href: "/projects/intranet-erp" }],
-    featured: true,
   },
 ];
 

--- a/src/lib/personSchema.ts
+++ b/src/lib/personSchema.ts
@@ -1,0 +1,50 @@
+import type { EducationItem, ExperienceItem, SiteMeta } from "../types";
+
+interface SchemaInput {
+  siteMeta: SiteMeta;
+  experienceItems: ExperienceItem[];
+  educationItems: EducationItem[];
+}
+
+export function buildPersonSchema({
+  siteMeta,
+  experienceItems,
+  educationItems,
+}: SchemaInput) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: siteMeta.name,
+    jobTitle: "Full-stack developer",
+    description: siteMeta.summary,
+    email: siteMeta.email,
+    url: "https://alaarab.com/",
+    sameAs: [siteMeta.linkedinHref, "https://github.com/alaarab"],
+    address: {
+      "@type": "PostalAddress",
+      addressLocality: "Sacramento",
+      addressRegion: "CA",
+      addressCountry: "US",
+    },
+    worksFor: experienceItems[0]
+      ? { "@type": "Organization", name: experienceItems[0].company }
+      : undefined,
+    alumniOf: educationItems.map((item) => ({
+      "@type": "EducationalOrganization",
+      name: item.school,
+    })),
+    hasOccupation: experienceItems.map((item) => ({
+      "@type": "EmployeeRole",
+      roleName: item.role,
+      startDate: extractStartYear(item.years),
+      employmentType: "FULL_TIME",
+      employer: { "@type": "Organization", name: item.company },
+      description: item.summary,
+    })),
+  };
+}
+
+function extractStartYear(years: string): string | undefined {
+  const match = years.match(/\d{4}/);
+  return match ? match[0] : undefined;
+}

--- a/src/lib/personSchema.ts
+++ b/src/lib/personSchema.ts
@@ -22,7 +22,7 @@ export function buildPersonSchema({
     sameAs: [siteMeta.linkedinHref, "https://github.com/alaarab"],
     address: {
       "@type": "PostalAddress",
-      addressLocality: "Sacramento",
+      addressLocality: "Los Angeles",
       addressRegion: "CA",
       addressCountry: "US",
     },

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -68,6 +68,12 @@ export function Home() {
           <div className={styles.sectionIntro}>
             <p className={styles.eyebrow}>Featured work</p>
             <h2>Selected work</h2>
+            <p className={styles.sectionNote}>
+              Two threads run through most of this. Tooling for AI coding
+              agents that fixes the "forgets everything between sessions"
+              problem, and tooling for music production that came out of
+              being annoyed at how Ableton handles version control.
+            </p>
           </div>
           <div className={styles.projectGrid}>
             {featuredProjects.map((project) => (
@@ -77,9 +83,16 @@ export function Home() {
                 style={accentStyle(project.accent)}
               >
                 <div className={styles.projectHeader}>
-                  <span className={styles.statusPill}>
-                    {project.category} · {project.year}
-                  </span>
+                  <div className={styles.pillRow}>
+                    <span className={styles.statusPill}>
+                      {project.category} · {project.year}
+                    </span>
+                    {project.thread ? (
+                      <span className={styles.threadPill}>
+                        {project.thread}
+                      </span>
+                    ) : null}
+                  </div>
                   <h3>{project.title}</h3>
                 </div>
                 <p>{project.summary}</p>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -64,13 +64,27 @@ export function Home() {
         Skip to content
       </a>
       <header className={styles.header}>
+        <div className={styles.marquee}>
+          <span>
+            <span className={styles.statusDot} aria-hidden="true" />
+            Open to selected consulting
+          </span>
+          <span className={styles.marqueeSep}>/</span>
+          <span>Los Angeles, CA</span>
+          <span className={styles.marqueeSep}>/</span>
+          <span>Systems Software Architect @ Qualus</span>
+          <span className={styles.marqueeSep}>/</span>
+          <span>May 2026</span>
+        </div>
         <div className={styles.navWrap}>
           <a href="#top" className={styles.wordmark}>
             {siteMeta.name}
           </a>
           <nav className={styles.nav}>
-            <a href="#projects">Projects</a>
+            <a href="#projects">Work</a>
             <a href="#experience">Experience</a>
+            <Link to="/now">Now</Link>
+            <Link to="/resume">Resume</Link>
             <a href="#contact">Contact</a>
           </nav>
         </div>
@@ -79,16 +93,19 @@ export function Home() {
       <main id="top" className={styles.main}>
         <section className={styles.hero}>
           <div className={styles.heroCopy}>
-            <p className={styles.eyebrow}>Portfolio</p>
-            <h1>{siteMeta.title}</h1>
+            <p className={styles.eyebrow}>Portfolio · 2026</p>
+            <h1>
+              Full-stack developer building web products and the{" "}
+              <em>unglamorous</em> tools that keep them running.
+            </h1>
             <p className={styles.heroText}>{siteMeta.intro}</p>
             <p className={styles.heroSubtext}>{siteMeta.summary}</p>
             <div className={styles.ctaRow}>
               <a className={styles.primaryCta} href="#projects">
-                View featured work
+                See the work
               </a>
               <Link className={styles.secondaryCta} to="/resume">
-                Resume
+                Read the resume
               </Link>
             </div>
           </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -16,6 +16,9 @@ export function Home() {
 
   return (
     <div className={styles.pageShell}>
+      <a className="skip-link" href="#top">
+        Skip to content
+      </a>
       <header className={styles.header}>
         <div className={styles.navWrap}>
           <a href="#top" className={styles.wordmark}>
@@ -152,10 +155,10 @@ export function Home() {
           <div className={styles.contactPanel}>
             <div>
               <p className={styles.eyebrow}>Contact</p>
-              <h2>Simple, direct, and easy to reach.</h2>
+              <h2>Say hi.</h2>
               <p className={styles.contactText}>
-                If you want to talk about a product build, an internal tool, or
-                a consulting project, get in touch.
+                Product work, internal tooling, or selected consulting. Email
+                lands; LinkedIn works; the resume is a click away.
               </p>
             </div>
             <ActionLinks links={contactLinks} className={styles.contactLinks} />
@@ -164,7 +167,18 @@ export function Home() {
       </main>
 
       <footer className={styles.footer}>
-        <p>{new Date().getFullYear()} Ala Arab</p>
+        <p>© {new Date().getFullYear()} Ala Arab</p>
+        <p className={styles.footerNote}>
+          Built with Bun, React 19, and TypeScript. Source on{" "}
+          <a
+            href="https://github.com/alaarab/alaarab"
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            GitHub
+          </a>
+          .
+        </p>
       </footer>
     </div>
   );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -203,7 +203,8 @@ export function Home() {
           >
             GitHub
           </a>
-          .
+          . What I'm focused on right{" "}
+          <Link to="/now">now</Link>.
         </p>
       </footer>
     </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -135,8 +135,9 @@ export function Home() {
             <p className={styles.sectionNote}>
               Two threads run through most of the open-source side. Tooling
               for AI coding agents that fixes the "forgets everything between
-              sessions" problem, and tooling for music production that came
-              out of being annoyed at how Ableton handles version control.
+              sessions" problem, and tooling for my own music — I produce
+              electronic music in Ableton and started writing the plugins
+              and bridges I kept wishing existed.
             </p>
           </div>
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -51,11 +51,12 @@ function FeaturedCard({ project }: { project: Project }) {
 export function Home() {
   useDocumentTitle(`${siteMeta.name} | Portfolio`);
 
-  const currentlyBuildingProjects = featuredProjects.filter(
-    (project) => project.category === "Open source",
+  const CURRENT_CATEGORIES = new Set(["Open source", "Current"]);
+  const currentlyBuildingProjects = featuredProjects.filter((project) =>
+    CURRENT_CATEGORIES.has(project.category),
   );
   const previouslyProjects = featuredProjects.filter(
-    (project) => project.category !== "Open source",
+    (project) => !CURRENT_CATEGORIES.has(project.category),
   );
 
   return (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -83,6 +83,13 @@ export function Home() {
                   <h3>{project.title}</h3>
                 </div>
                 <p>{project.summary}</p>
+                {project.metrics && project.metrics.length > 0 ? (
+                  <ul className={styles.metricsList}>
+                    {project.metrics.map((metric) => (
+                      <li key={metric}>{metric}</li>
+                    ))}
+                  </ul>
+                ) : null}
                 <p className={styles.outcome}>{project.outcome}</p>
                 <ul className={styles.tagList}>
                   {project.stack.map((item) => (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -10,9 +10,53 @@ import {
 } from "../data/siteContent";
 import { useDocumentTitle } from "../lib/useDocumentTitle";
 import styles from "../styles/Portfolio.module.css";
+import type { Project } from "../types";
+
+function FeaturedCard({ project }: { project: Project }) {
+  return (
+    <article
+      className={styles.projectCard}
+      style={accentStyle(project.accent)}
+    >
+      <div className={styles.projectHeader}>
+        <div className={styles.pillRow}>
+          <span className={styles.statusPill}>
+            {project.category} · {project.year}
+          </span>
+          {project.thread ? (
+            <span className={styles.threadPill}>{project.thread}</span>
+          ) : null}
+        </div>
+        <h3>{project.title}</h3>
+      </div>
+      <p>{project.summary}</p>
+      {project.metrics && project.metrics.length > 0 ? (
+        <ul className={styles.metricsList}>
+          {project.metrics.map((metric) => (
+            <li key={metric}>{metric}</li>
+          ))}
+        </ul>
+      ) : null}
+      <p className={styles.outcome}>{project.outcome}</p>
+      <ul className={styles.tagList}>
+        {project.stack.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+      <ActionLinks links={project.links} className={styles.projectLinks} />
+    </article>
+  );
+}
 
 export function Home() {
   useDocumentTitle(`${siteMeta.name} | Portfolio`);
+
+  const currentlyBuildingProjects = featuredProjects.filter(
+    (project) => project.category === "Open source",
+  );
+  const previouslyProjects = featuredProjects.filter(
+    (project) => project.category !== "Open source",
+  );
 
   return (
     <div className={styles.pageShell}>
@@ -72,53 +116,35 @@ export function Home() {
             <p className={styles.eyebrow}>Featured work</p>
             <h2>Selected work</h2>
             <p className={styles.sectionNote}>
-              Two threads run through most of this. Tooling for AI coding
-              agents that fixes the "forgets everything between sessions"
-              problem, and tooling for music production that came out of
-              being annoyed at how Ableton handles version control.
+              Two threads run through most of the open-source side. Tooling
+              for AI coding agents that fixes the "forgets everything between
+              sessions" problem, and tooling for music production that came
+              out of being annoyed at how Ableton handles version control.
             </p>
           </div>
-          <div className={styles.projectGrid}>
-            {featuredProjects.map((project) => (
-              <article
-                key={project.slug}
-                className={styles.projectCard}
-                style={accentStyle(project.accent)}
-              >
-                <div className={styles.projectHeader}>
-                  <div className={styles.pillRow}>
-                    <span className={styles.statusPill}>
-                      {project.category} · {project.year}
-                    </span>
-                    {project.thread ? (
-                      <span className={styles.threadPill}>
-                        {project.thread}
-                      </span>
-                    ) : null}
-                  </div>
-                  <h3>{project.title}</h3>
-                </div>
-                <p>{project.summary}</p>
-                {project.metrics && project.metrics.length > 0 ? (
-                  <ul className={styles.metricsList}>
-                    {project.metrics.map((metric) => (
-                      <li key={metric}>{metric}</li>
-                    ))}
-                  </ul>
-                ) : null}
-                <p className={styles.outcome}>{project.outcome}</p>
-                <ul className={styles.tagList}>
-                  {project.stack.map((item) => (
-                    <li key={item}>{item}</li>
-                  ))}
-                </ul>
-                <ActionLinks
-                  links={project.links}
-                  className={styles.projectLinks}
-                />
-              </article>
-            ))}
-          </div>
+
+          {currentlyBuildingProjects.length > 0 ? (
+            <div className={styles.featuredGroup}>
+              <p className={styles.featuredGroupLabel}>Currently building</p>
+              <div className={styles.projectGrid}>
+                {currentlyBuildingProjects.map((project) => (
+                  <FeaturedCard key={project.slug} project={project} />
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {previouslyProjects.length > 0 ? (
+            <div className={styles.featuredGroup}>
+              <p className={styles.featuredGroupLabel}>Previously</p>
+              <div className={styles.projectGrid}>
+                {previouslyProjects.map((project) => (
+                  <FeaturedCard key={project.slug} project={project} />
+                ))}
+              </div>
+            </div>
+          ) : null}
+
           <div className={styles.sectionCtaRow}>
             <Link className={styles.secondaryCta} to="/projects">
               All projects

--- a/src/pages/Now.tsx
+++ b/src/pages/Now.tsx
@@ -1,0 +1,45 @@
+import { Link } from "react-router";
+import { nowItems, nowMeta, siteMeta } from "../data/siteContent";
+import { useDocumentTitle } from "../lib/useDocumentTitle";
+import styles from "../styles/Portfolio.module.css";
+
+export function Now() {
+  useDocumentTitle(`Now | ${siteMeta.name}`);
+
+  return (
+    <div className={styles.projectsShell}>
+      <header className={styles.projectsHeader}>
+        <div>
+          <p className={styles.eyebrow}>What I'm doing now</p>
+          <h1>Current focus</h1>
+          <p className={styles.heroText}>{nowMeta.intro}</p>
+          <p className={styles.sectionNote}>
+            As of {nowMeta.asOf}. Inspired by{" "}
+            <a
+              href="https://nownownow.com/about"
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              nownownow.com
+            </a>
+            .
+          </p>
+        </div>
+        <div className={styles.resumeLinks}>
+          <Link to="/">Portfolio</Link>
+          <Link to="/projects">Projects</Link>
+          <Link to="/resume">Resume</Link>
+        </div>
+      </header>
+
+      <ul className={styles.nowList}>
+        {nowItems.map((item) => (
+          <li key={item.heading} className={styles.nowItem}>
+            <h2>{item.heading}</h2>
+            <p>{item.body}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -4,7 +4,23 @@ import { projects, siteMeta } from "../data/siteContent";
 import { accentStyle } from "../lib/accentStyle";
 import { useDocumentTitle } from "../lib/useDocumentTitle";
 import styles from "../styles/Portfolio.module.css";
+import type { Project } from "../types";
 import { NotFound } from "./NotFound";
+
+function pickRelated(current: Project, all: Project[]): Project[] {
+  const sameThread = current.thread
+    ? all.filter(
+        (item) => item.slug !== current.slug && item.thread === current.thread,
+      )
+    : [];
+  const sameCategory = all.filter(
+    (item) =>
+      item.slug !== current.slug &&
+      item.category === current.category &&
+      !sameThread.includes(item),
+  );
+  return [...sameThread, ...sameCategory].slice(0, 3);
+}
 
 export function ProjectDetail() {
   const { slug } = useParams<{ slug: string }>();
@@ -20,6 +36,8 @@ export function ProjectDetail() {
     return <NotFound />;
   }
 
+  const related = pickRelated(project, projects);
+
   return (
     <div className={styles.projectPageShell} style={accentStyle(project.accent)}>
       <header className={styles.projectPageHeader}>
@@ -29,7 +47,12 @@ export function ProjectDetail() {
           <Link to="/resume">Resume</Link>
         </div>
         <div className={styles.projectHero}>
-          <p className={styles.eyebrow}>{project.category}</p>
+          <div className={styles.pillRow}>
+            <p className={styles.eyebrow}>{project.category}</p>
+            {project.thread ? (
+              <span className={styles.threadPill}>{project.thread}</span>
+            ) : null}
+          </div>
           <h1>{project.title}</h1>
           <p className={styles.heroText}>{project.summary}</p>
           {project.metrics && project.metrics.length > 0 ? (
@@ -50,6 +73,12 @@ export function ProjectDetail() {
             <strong>{project.status}</strong>
           </div>
         </div>
+        {project.links.length > 0 ? (
+          <ActionLinks
+            links={project.links}
+            className={styles.projectHeaderLinks}
+          />
+        ) : null}
       </header>
 
       <main className={styles.projectStoryGrid}>
@@ -72,9 +101,38 @@ export function ProjectDetail() {
               <li key={item}>{item}</li>
             ))}
           </ul>
-          <ActionLinks links={project.links} className={styles.projectLinks} />
         </section>
       </main>
+
+      {related.length > 0 ? (
+        <section className={styles.relatedSection}>
+          <div className={styles.sectionIntro}>
+            <p className={styles.eyebrow}>Related</p>
+            <h2>Next door</h2>
+          </div>
+          <div className={styles.relatedGrid}>
+            {related.map((item) => (
+              <Link
+                key={item.slug}
+                to={`/projects/${item.slug}`}
+                className={styles.relatedCard}
+                style={accentStyle(item.accent)}
+              >
+                <div className={styles.pillRow}>
+                  <span className={styles.statusPill}>
+                    {item.category} · {item.year}
+                  </span>
+                  {item.thread ? (
+                    <span className={styles.threadPill}>{item.thread}</span>
+                  ) : null}
+                </div>
+                <h3>{item.title}</h3>
+                <p>{item.summary}</p>
+              </Link>
+            ))}
+          </div>
+        </section>
+      ) : null}
     </div>
   );
 }

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -32,6 +32,13 @@ export function ProjectDetail() {
           <p className={styles.eyebrow}>{project.category}</p>
           <h1>{project.title}</h1>
           <p className={styles.heroText}>{project.summary}</p>
+          {project.metrics && project.metrics.length > 0 ? (
+            <ul className={styles.metricsList}>
+              {project.metrics.map((metric) => (
+                <li key={metric}>{metric}</li>
+              ))}
+            </ul>
+          ) : null}
         </div>
         <div className={styles.projectFacts}>
           <div>

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -81,6 +81,13 @@ export function ProjectDetail() {
         ) : null}
       </header>
 
+      {project.quote ? (
+        <blockquote className={styles.projectQuote}>
+          <p>{project.quote}</p>
+          <cite>— from the project README</cite>
+        </blockquote>
+      ) : null}
+
       <main className={styles.projectStoryGrid}>
         <section className={styles.storyCard}>
           <h2>Overview</h2>

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -3,9 +3,37 @@ import { projects, siteMeta } from "../data/siteContent";
 import { accentStyle } from "../lib/accentStyle";
 import { useDocumentTitle } from "../lib/useDocumentTitle";
 import styles from "../styles/Portfolio.module.css";
+import type { Project } from "../types";
+
+const CATEGORY_ORDER = [
+  "Open source",
+  "Flagship product",
+  "Current",
+  "Client work",
+  "Legacy case study",
+];
+
+function groupByCategory(items: Project[]): Array<[string, Project[]]> {
+  const groups = new Map<string, Project[]>();
+  for (const item of items) {
+    const bucket = groups.get(item.category) ?? [];
+    bucket.push(item);
+    groups.set(item.category, bucket);
+  }
+  const ordered: Array<[string, Project[]]> = [];
+  for (const category of CATEGORY_ORDER) {
+    const bucket = groups.get(category);
+    if (bucket && bucket.length > 0) ordered.push([category, bucket]);
+    groups.delete(category);
+  }
+  for (const entry of groups) ordered.push(entry);
+  return ordered;
+}
 
 export function Projects() {
   useDocumentTitle(`${siteMeta.name} | Projects`);
+
+  const groups = groupByCategory(projects);
 
   return (
     <div className={styles.projectsShell}>
@@ -24,30 +52,40 @@ export function Projects() {
         </div>
       </header>
 
-      <main className={styles.projectsList}>
-        {projects.map((project) => (
-          <article
-            key={project.slug}
-            className={styles.projectListCard}
-            style={accentStyle(project.accent)}
-          >
-            <div className={styles.projectListMeta}>
-              <span>{project.category}</span>
-              <span>{project.year}</span>
+      <main className={styles.projectsGroups}>
+        {groups.map(([category, items]) => (
+          <section key={category} className={styles.projectsGroup}>
+            <div className={styles.projectsGroupHeading}>
+              <h2>{category}</h2>
+              <span>{items.length}</span>
             </div>
-            <div className={styles.projectListBody}>
-              <h2>{project.title}</h2>
-              <p>{project.summary}</p>
-              <ul className={styles.tagList}>
-                {project.stack.map((item) => (
-                  <li key={item}>{item}</li>
-                ))}
-              </ul>
+            <div className={styles.projectsList}>
+              {items.map((project) => (
+                <article
+                  key={project.slug}
+                  className={styles.projectListCard}
+                  style={accentStyle(project.accent)}
+                >
+                  <div className={styles.projectListMeta}>
+                    <span>{project.category}</span>
+                    <span>{project.year}</span>
+                  </div>
+                  <div className={styles.projectListBody}>
+                    <h3>{project.title}</h3>
+                    <p>{project.summary}</p>
+                    <ul className={styles.tagList}>
+                      {project.stack.map((item) => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div className={styles.projectLinks}>
+                    <Link to={`/projects/${project.slug}`}>View project</Link>
+                  </div>
+                </article>
+              ))}
             </div>
-            <div className={styles.projectLinks}>
-              <Link to={`/projects/${project.slug}`}>View project</Link>
-            </div>
-          </article>
+          </section>
         ))}
       </main>
     </div>

--- a/src/pages/Resume.tsx
+++ b/src/pages/Resume.tsx
@@ -6,13 +6,25 @@ import {
   siteMeta,
 } from "../data/siteContent";
 import { useDocumentTitle } from "../lib/useDocumentTitle";
+import { buildPersonSchema } from "../lib/personSchema";
 import styles from "../styles/Portfolio.module.css";
 
 export function Resume() {
   useDocumentTitle(`${siteMeta.name} | Resume`);
 
+  const personSchema = buildPersonSchema({
+    siteMeta,
+    experienceItems,
+    educationItems,
+  });
+
   return (
     <div className={styles.resumeShell}>
+      <script
+        type="application/ld+json"
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: trusted, locally generated JSON
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(personSchema) }}
+      />
       <header className={styles.resumeHeader}>
         <div>
           <p className={styles.eyebrow}>Resume</p>

--- a/src/pages/Resume.tsx
+++ b/src/pages/Resume.tsx
@@ -19,12 +19,19 @@ export function Resume() {
           <h1>{siteMeta.name}</h1>
           <p className={styles.resumeLead}>{siteMeta.title}</p>
         </div>
-        <div className={styles.resumeLinks}>
+        <div className={styles.resumeLinks} data-print-hide>
           <Link to="/">Back to portfolio</Link>
           <a href={siteMeta.emailHref}>Email</a>
           <a href={siteMeta.linkedinHref} target="_blank" rel="noreferrer">
             LinkedIn
           </a>
+          <button
+            type="button"
+            className={styles.printButton}
+            onClick={() => window.print()}
+          >
+            Print or save as PDF
+          </button>
         </div>
       </header>
 

--- a/src/styles/Portfolio.module.css
+++ b/src/styles/Portfolio.module.css
@@ -649,6 +649,40 @@
   margin-top: 1rem;
 }
 
+.projectsGroups {
+  display: grid;
+  gap: 1.6rem;
+  margin-top: 1rem;
+}
+
+.projectsGroup {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.projectsGroupHeading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.4rem 0.2rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.projectsGroupHeading h2 {
+  font-family: var(--font-display), "Trebuchet MS", sans-serif;
+  font-size: clamp(1.4rem, 2.4vw, 1.9rem);
+  letter-spacing: -0.03em;
+}
+
+.projectsGroupHeading span {
+  font-family: var(--font-mono), "Courier New", monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
 .projectListCard {
   display: grid;
   grid-template-columns: minmax(180px, 0.35fr) minmax(0, 1fr) auto;

--- a/src/styles/Portfolio.module.css
+++ b/src/styles/Portfolio.module.css
@@ -874,6 +874,45 @@
   margin-top: 1rem;
 }
 
+.projectQuote {
+  position: relative;
+  margin: 1.4rem 0 0;
+  padding: 1.4rem 1.6rem 1.4rem 2.2rem;
+  border-radius: 1.4rem;
+  background: color-mix(
+    in srgb,
+    var(--project-accent, var(--accent)) 8%,
+    rgba(255, 250, 243, 0.85)
+  );
+  border: 1px solid var(--line);
+  font-family: var(--font-display), "Trebuchet MS", sans-serif;
+  font-size: 1.1rem;
+  line-height: 1.45;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+}
+
+.projectQuote::before {
+  content: "\201C";
+  position: absolute;
+  top: 0.4rem;
+  left: 0.9rem;
+  font-size: 2.4rem;
+  line-height: 1;
+  color: color-mix(in srgb, var(--project-accent, var(--accent)) 60%, transparent);
+}
+
+.projectQuote cite {
+  display: block;
+  margin-top: 0.6rem;
+  font-family: var(--font-mono), "Courier New", monospace;
+  font-size: 0.72rem;
+  font-style: normal;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
 .storyCard {
   display: grid;
   gap: 0.9rem;

--- a/src/styles/Portfolio.module.css
+++ b/src/styles/Portfolio.module.css
@@ -259,6 +259,13 @@
   margin-bottom: 1.25rem;
 }
 
+.sectionNote {
+  max-width: 52ch;
+  margin-top: 0.4rem;
+  color: var(--ink-soft);
+  line-height: 1.6;
+}
+
 .sectionIntro h2,
 .contactPanel h2,
 .resumeSection h2 {
@@ -406,6 +413,25 @@
   );
   color: color-mix(in srgb, var(--project-accent, var(--accent)) 82%, var(--ink));
   font-size: 0.72rem;
+  text-transform: uppercase;
+}
+
+.pillRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  align-items: center;
+}
+
+.threadPill {
+  padding: 0.32rem 0.6rem;
+  border-radius: 999px;
+  border: 1px dashed
+    color-mix(in srgb, var(--project-accent, var(--accent)) 50%, var(--line));
+  color: var(--ink-soft);
+  font-family: var(--font-mono), "Courier New", monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 

--- a/src/styles/Portfolio.module.css
+++ b/src/styles/Portfolio.module.css
@@ -804,6 +804,93 @@
   gap: 0.9rem;
 }
 
+.projectHeaderLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-top: 0.8rem;
+}
+
+.projectHeaderLinks a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.6rem;
+  padding: 0 1rem;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: rgba(255, 250, 243, 0.82);
+}
+
+.projectHeaderLinks a:hover {
+  border-color: color-mix(
+    in srgb,
+    var(--project-accent, var(--accent)) 38%,
+    var(--line)
+  );
+  color: var(--accent-strong);
+}
+
+.relatedSection {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border: 1px solid var(--line);
+  border-radius: 1.8rem;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.relatedGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.relatedCard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 1.1rem;
+  border: 1px solid var(--line);
+  border-radius: 1.2rem;
+  background: rgba(255, 250, 243, 0.7);
+  transition:
+    transform 200ms ease,
+    border-color 200ms ease,
+    box-shadow 200ms ease;
+}
+
+.relatedCard:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(
+    in srgb,
+    var(--project-accent, var(--accent)) 32%,
+    var(--line)
+  );
+  box-shadow:
+    0 16px 32px
+      color-mix(in srgb, var(--project-accent, var(--accent)) 14%, transparent),
+    var(--shadow);
+}
+
+.relatedCard h3 {
+  font-size: 1.05rem;
+  letter-spacing: -0.02em;
+}
+
+.relatedCard p {
+  color: var(--ink-soft);
+  line-height: 1.55;
+  font-size: 0.92rem;
+}
+
+@media (max-width: 920px) {
+  .relatedGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 920px) {
   .hero,
   .dualGrid,

--- a/src/styles/Portfolio.module.css
+++ b/src/styles/Portfolio.module.css
@@ -306,10 +306,25 @@
 }
 
 .projectListCard {
+  position: relative;
+  overflow: hidden;
   transition:
     transform 220ms cubic-bezier(0.2, 0.7, 0.2, 1),
     box-shadow 220ms ease,
     border-color 220ms ease;
+}
+
+.projectListCard::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  background: color-mix(
+    in srgb,
+    var(--project-accent, var(--accent)) 70%,
+    transparent
+  );
+  opacity: 0.85;
 }
 
 .projectListCard:hover {
@@ -400,15 +415,36 @@
 }
 
 .projectCard {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 1rem;
   padding: 1.55rem;
   border-radius: 1.8rem;
+  overflow: hidden;
   transition:
     transform 220ms cubic-bezier(0.2, 0.7, 0.2, 1),
     box-shadow 220ms ease,
     border-color 220ms ease;
+}
+
+.projectCard::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  background: color-mix(
+    in srgb,
+    var(--project-accent, var(--accent)) 70%,
+    transparent
+  );
+  opacity: 0.85;
+  transition: width 200ms ease, opacity 200ms ease;
+}
+
+.projectCard:hover::before {
+  width: 6px;
+  opacity: 1;
 }
 
 .projectCard:hover {
@@ -887,6 +923,7 @@
 }
 
 .relatedCard {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
@@ -894,10 +931,24 @@
   border: 1px solid var(--line);
   border-radius: 1.2rem;
   background: rgba(255, 250, 243, 0.7);
+  overflow: hidden;
   transition:
     transform 200ms ease,
     border-color 200ms ease,
     box-shadow 200ms ease;
+}
+
+.relatedCard::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: color-mix(
+    in srgb,
+    var(--project-accent, var(--accent)) 70%,
+    transparent
+  );
+  opacity: 0.85;
 }
 
 .relatedCard:hover {

--- a/src/styles/Portfolio.module.css
+++ b/src/styles/Portfolio.module.css
@@ -606,6 +606,17 @@
   font-size: 0.95rem;
 }
 
+.footerNote a {
+  color: var(--accent-strong);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--accent) 35%, transparent);
+  text-underline-offset: 3px;
+}
+
+.footerNote a:hover {
+  text-decoration-color: var(--accent-strong);
+}
+
 .resumeShell {
   max-width: 980px;
   margin: 0 auto;

--- a/src/styles/Portfolio.module.css
+++ b/src/styles/Portfolio.module.css
@@ -1,12 +1,68 @@
+/* ============================================================
+   Shell + Header
+   ============================================================ */
+
 .pageShell {
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 .header {
   position: sticky;
   top: 0;
-  z-index: 10;
-  padding: 1.2rem 1.4rem 0;
+  z-index: 20;
+  background: linear-gradient(
+    180deg,
+    rgba(14, 12, 10, 0.92) 0%,
+    rgba(14, 12, 10, 0.72) 70%,
+    rgba(14, 12, 10, 0) 100%
+  );
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  padding-bottom: 0.4rem;
+}
+
+.marquee {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.55rem 1.6rem;
+  border-bottom: 1px solid var(--line);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.marquee span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.marqueeSep {
+  color: var(--accent);
+  opacity: 0.7;
+}
+
+.statusDot {
+  display: inline-block;
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 999px;
+  background: var(--accent-cool);
+  box-shadow: 0 0 12px var(--accent-cool);
+  animation: pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
 }
 
 .navWrap {
@@ -14,397 +70,387 @@
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  max-width: 1120px;
+  max-width: 1240px;
   margin: 0 auto;
-  padding: 0.9rem 1.1rem;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  background: rgba(255, 250, 243, 0.72);
-  backdrop-filter: blur(18px);
-  box-shadow: var(--shadow);
+  padding: 1rem 1.6rem 0.4rem;
 }
 
 .wordmark {
-  font-size: 0.95rem;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
+  color: var(--ink);
+}
+
+.wordmark::before {
+  content: "▮";
+  color: var(--accent);
+  font-size: 0.7rem;
+  transform: translateY(-1px);
 }
 
 .nav {
   display: flex;
   align-items: center;
-  gap: 1.1rem;
+  gap: 1.6rem;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
   color: var(--ink-soft);
-  font-size: 0.95rem;
 }
 
-.nav a:hover,
-.wordmark:hover {
-  color: var(--accent-strong);
+.nav a {
+  position: relative;
+  padding: 0.2rem 0;
+  transition: color 150ms ease;
+}
+
+.nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -0.15rem;
+  height: 1px;
+  background: var(--accent);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 200ms ease;
+}
+
+.nav a:hover {
+  color: var(--ink);
+}
+
+.nav a:hover::after {
+  transform: scaleX(1);
 }
 
 .main {
-  max-width: 1120px;
+  flex: 1;
+  max-width: 1240px;
+  width: 100%;
   margin: 0 auto;
-  padding: 3rem 1.4rem 5rem;
+  padding: 1rem 1.6rem 5rem;
 }
+
+/* ============================================================
+   Hero
+   ============================================================ */
 
 .hero {
   display: grid;
-  grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.85fr);
-  gap: 1.5rem;
-  align-items: stretch;
-  padding: 3rem 0 1.5rem;
+  grid-template-columns: minmax(0, 1.65fr) minmax(280px, 0.78fr);
+  gap: 3rem;
+  align-items: start;
+  padding: 5rem 0 4rem;
+  position: relative;
 }
 
-.heroCopy,
-.heroPanel,
-.surfaceCard,
-.projectCard,
-.contactPanel,
-.resumeCard {
-  border: 1px solid var(--line);
-  background: var(--surface);
-  backdrop-filter: blur(18px);
-  box-shadow: var(--shadow);
+.hero::before {
+  content: "";
+  position: absolute;
+  top: 1.6rem;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    var(--accent) 0%,
+    var(--accent) 4rem,
+    var(--line) 4rem,
+    var(--line) 100%
+  );
 }
 
 .heroCopy {
-  padding: 2.2rem;
-  border-radius: 2rem;
-}
-
-.heroCopy h1,
-.sectionIntro h2,
-.contactPanel h2,
-.resumeHeader h1,
-.resumeSection h2 {
-  font-family: var(--font-display), "Trebuchet MS", sans-serif;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
 }
 
 .heroCopy h1 {
-  max-width: 11ch;
-  font-size: clamp(3rem, 7vw, 5.8rem);
-  line-height: 0.95;
-  letter-spacing: -0.05em;
+  font-family: var(--font-display);
+  font-size: clamp(3.2rem, 8.5vw, 7.4rem);
+  font-weight: 400;
+  font-style: italic;
+  font-variation-settings: "opsz" 144, "SOFT" 100;
+  line-height: 0.92;
+  letter-spacing: -0.045em;
+  color: var(--ink);
+  text-wrap: balance;
 }
 
-.eyebrow,
-.panelLabel,
-.statusPill,
-.timelineMeta,
-.resumeMeta {
-  font-family: var(--font-mono), "Courier New", monospace;
-  letter-spacing: 0.06em;
+.heroCopy h1 em {
+  font-style: normal;
+  font-weight: 600;
+  color: var(--accent);
 }
 
 .eyebrow {
-  margin-bottom: 1rem;
-  color: var(--project-accent, var(--accent));
-  font-size: 0.8rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
   font-weight: 500;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
+  color: var(--ink-dim);
 }
 
-.heroText,
-.heroSubtext,
-.contactText,
-.timelineContent p,
-.resumeCard p,
-.projectCard p {
-  color: var(--ink-soft);
-  line-height: 1.65;
+.eyebrow::before {
+  content: "";
+  display: inline-block;
+  width: 1.4rem;
+  height: 1px;
+  background: var(--accent);
 }
 
 .heroText {
-  max-width: 42rem;
-  margin-top: 1.4rem;
-  font-size: 1.08rem;
+  max-width: 36rem;
+  font-size: 1.15rem;
+  line-height: 1.55;
+  color: var(--ink);
+  font-weight: 400;
 }
 
 .heroSubtext {
-  max-width: 40rem;
-  margin-top: 1rem;
+  max-width: 38rem;
+  color: var(--ink-soft);
+  font-size: 0.98rem;
+  line-height: 1.65;
 }
 
 .ctaRow {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.85rem;
-  margin-top: 2rem;
-}
-
-.primaryCta,
-.secondaryCta,
-.contactLinks a,
-.resumeLinks a,
-.projectLinks a {
-  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  min-height: 2.8rem;
-  border-radius: 999px;
-  transition:
-    transform 150ms ease,
-    background-color 150ms ease,
-    border-color 150ms ease,
-    color 150ms ease;
-}
-
-.primaryCta,
-.secondaryCta,
-.resumeLinks a {
-  padding: 0 1.15rem;
+  gap: 1.2rem;
+  margin-top: 0.6rem;
 }
 
 .primaryCta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.85rem 1.3rem;
   background: var(--accent);
-  color: #f6fbfa;
+  color: var(--bg);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: transform 150ms ease, background 150ms ease;
 }
 
-.primaryCta:hover,
-.contactLinks a:hover,
-.resumeLinks a:hover,
-.projectLinks a:hover {
-  transform: translateY(-1px);
+.primaryCta::after {
+  content: "→";
+  transition: transform 200ms ease;
 }
 
-.secondaryCta,
-.contactLinks a,
-.resumeLinks a,
-.projectLinks a {
-  border: 1px solid var(--line);
-  background: rgba(255, 250, 243, 0.82);
+.primaryCta:hover {
+  background: var(--accent-soft);
 }
 
-.secondaryCta:hover,
-.contactLinks a:hover,
-.resumeLinks a:hover,
-.projectLinks a:hover {
-  border-color: rgba(15, 118, 110, 0.28);
-  color: var(--accent-strong);
+.primaryCta:hover::after {
+  transform: translateX(3px);
 }
 
+.secondaryCta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.85rem 0;
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--line-strong);
+  transition: border-color 150ms ease, color 150ms ease;
+}
+
+.secondaryCta:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+/* Hero side panel — field notes style, not a card */
 .heroPanel {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  gap: 1.4rem;
-  padding: 1.6rem;
-  border-radius: 1.75rem;
+  gap: 1.6rem;
+  padding-top: 0.4rem;
 }
 
 .panelLabel {
-  color: var(--ink-soft);
-  font-size: 0.8rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-}
-
-.statList,
-.bulletList,
-.tagList {
-  padding: 0;
-  list-style: none;
+  color: var(--ink-dim);
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--line);
 }
 
 .statList {
-  display: grid;
-  gap: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  padding: 0;
+  list-style: none;
 }
 
 .statList li {
   display: flex;
   flex-direction: column;
-  gap: 0.28rem;
-  padding-bottom: 1rem;
-  border-bottom: 1px solid var(--line);
+  gap: 0.3rem;
 }
 
-.statList li:last-child {
-  padding-bottom: 0;
-  border-bottom: 0;
+.statList li > span {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
 }
 
-.statList span,
-.contactBlock {
-  color: var(--ink-soft);
-}
-
-.statList strong {
-  font-size: 1.05rem;
+.statList li > strong {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: 1.15rem;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  font-variation-settings: "opsz" 16;
 }
 
 .contactBlock {
   display: flex;
   flex-direction: column;
-  gap: 0.55rem;
-  padding: 1rem;
-  border-radius: 1.2rem;
-  background: rgba(239, 231, 219, 0.76);
+  gap: 0.7rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--line);
+}
+
+.contactBlock > span {
+  font-size: 0.92rem;
+  color: var(--ink-soft);
+  line-height: 1.5;
 }
 
 .contactBlock a {
-  color: var(--accent-strong);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  width: fit-content;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  border-bottom: 1px solid transparent;
+  transition: border-color 150ms ease;
 }
 
+.contactBlock a:hover {
+  border-color: var(--accent);
+}
+
+.contactBlock a::after {
+  content: "↗";
+  font-weight: 700;
+}
+
+/* ============================================================
+   Sections
+   ============================================================ */
+
 .section {
-  padding: 1.5rem 0 0;
+  padding: 4rem 0 0;
+  position: relative;
+}
+
+.section::before {
+  content: "";
+  display: block;
+  width: 100%;
+  height: 1px;
+  background: var(--line);
+  margin-bottom: 3rem;
 }
 
 .sectionIntro {
   display: flex;
   flex-direction: column;
-  gap: 0.55rem;
-  margin-bottom: 1.25rem;
-}
-
-.sectionNote {
-  max-width: 52ch;
-  margin-top: 0.4rem;
-  color: var(--ink-soft);
-  line-height: 1.6;
+  gap: 1rem;
+  margin-bottom: 2.8rem;
+  max-width: 56rem;
 }
 
 .sectionIntro h2,
 .contactPanel h2,
 .resumeSection h2 {
-  font-size: clamp(1.8rem, 3vw, 2.8rem);
-  line-height: 1;
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-style: italic;
+  font-variation-settings: "opsz" 144, "SOFT" 100;
+  font-size: clamp(2.2rem, 5vw, 4rem);
+  line-height: 0.95;
   letter-spacing: -0.04em;
-}
-
-.dualGrid,
-.projectGrid,
-.principlesGrid,
-.projectStoryGrid {
-  display: grid;
-  gap: 1rem;
-}
-
-.dualGrid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.principlesGrid {
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.surfaceCard {
-  padding: 1.5rem;
-  border-radius: 1.6rem;
-}
-
-.principleCard,
-.storyCard,
-.projectListCard {
-  padding: 1.25rem;
-  border: 1px solid var(--line);
-  border-radius: 1.4rem;
-  background: var(--surface);
-  box-shadow: var(--shadow);
-}
-
-.projectListCard {
-  position: relative;
-  overflow: hidden;
-  transition:
-    transform 220ms cubic-bezier(0.2, 0.7, 0.2, 1),
-    box-shadow 220ms ease,
-    border-color 220ms ease;
-}
-
-.projectListCard::before {
-  content: "";
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: 4px;
-  background: color-mix(
-    in srgb,
-    var(--project-accent, var(--accent)) 70%,
-    transparent
-  );
-  opacity: 0.85;
-}
-
-.projectListCard:hover {
-  transform: translateY(-3px);
-  border-color: color-mix(
-    in srgb,
-    var(--project-accent, var(--accent)) 36%,
-    var(--line)
-  );
-  box-shadow:
-    0 22px 44px
-      color-mix(in srgb, var(--project-accent, var(--accent)) 18%, transparent),
-    var(--shadow);
-}
-
-.principleCard p {
   color: var(--ink);
-  line-height: 1.6;
 }
 
-.surfaceCard h3,
-.projectCard h3,
-.timelineContent h3,
-.resumeCard h3 {
-  font-size: 1.2rem;
-  letter-spacing: -0.03em;
-}
-
-.surfaceCard h3,
-.timelineContent h3,
-.resumeCard h3 {
-  margin-bottom: 0.8rem;
-}
-
-.bulletList {
-  display: grid;
-  gap: 0.8rem;
-}
-
-.bulletList li {
-  position: relative;
-  padding-left: 1.15rem;
+.sectionNote {
+  max-width: 54ch;
   color: var(--ink-soft);
-  line-height: 1.6;
+  font-size: 1rem;
+  line-height: 1.65;
 }
 
-.bulletList li::before {
-  content: "";
-  position: absolute;
-  top: 0.68rem;
-  left: 0;
-  width: 0.42rem;
-  height: 0.42rem;
-  border-radius: 999px;
-  background: var(--accent-warm);
-}
-
-.projectGrid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
+/* ============================================================
+   Project Grid (Featured Cards)
+   ============================================================ */
 
 .featuredGroup {
   display: grid;
-  gap: 0.7rem;
-  margin-top: 1.6rem;
+  gap: 1.2rem;
+  margin-top: 2.6rem;
 }
 
 .featuredGroup:first-of-type {
-  margin-top: 0.4rem;
+  margin-top: 0;
 }
 
 .featuredGroupLabel {
   display: inline-flex;
   align-items: center;
-  gap: 0.6rem;
-  font-family: var(--font-mono), "Courier New", monospace;
-  font-size: 0.78rem;
-  letter-spacing: 0.1em;
+  gap: 0.7rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--ink-soft);
+  color: var(--ink-dim);
+  padding-bottom: 0.4rem;
+}
+
+.featuredGroupLabel::before {
+  content: "◯";
+  color: var(--accent);
+  font-size: 0.55rem;
 }
 
 .featuredGroupLabel::after {
@@ -412,72 +458,91 @@
   flex: 1;
   height: 1px;
   background: var(--line);
+  margin-left: 0.4rem;
+}
+
+.projectGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.2rem;
 }
 
 .projectCard {
+  --pa: var(--project-accent, var(--accent));
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 1.55rem;
-  border-radius: 1.8rem;
+  gap: 1.1rem;
+  padding: 1.8rem 1.6rem 1.6rem;
+  background: var(--bg-elev);
+  border: 1px solid var(--line);
   overflow: hidden;
   transition:
-    transform 220ms cubic-bezier(0.2, 0.7, 0.2, 1),
-    box-shadow 220ms ease,
-    border-color 220ms ease;
+    transform 250ms cubic-bezier(0.2, 0.7, 0.2, 1),
+    border-color 200ms ease,
+    background 200ms ease;
 }
 
 .projectCard::before {
   content: "";
   position: absolute;
-  inset: 0 auto 0 0;
-  width: 4px;
-  background: color-mix(
-    in srgb,
-    var(--project-accent, var(--accent)) 70%,
-    transparent
-  );
-  opacity: 0.85;
-  transition: width 200ms ease, opacity 200ms ease;
+  inset: 0 0 auto 0;
+  height: 4px;
+  background: var(--pa);
+  transition: height 200ms ease;
 }
 
-.projectCard:hover::before {
-  width: 6px;
-  opacity: 1;
+.projectCard::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 7rem;
+  height: 7rem;
+  background: radial-gradient(
+    circle at top right,
+    color-mix(in srgb, var(--pa) 22%, transparent),
+    transparent 70%
+  );
+  pointer-events: none;
+  opacity: 0.7;
+  transition: opacity 250ms ease;
 }
 
 .projectCard:hover {
-  transform: translateY(-4px);
-  border-color: color-mix(
-    in srgb,
-    var(--project-accent, var(--accent)) 38%,
-    var(--line)
-  );
-  box-shadow:
-    0 26px 52px
-      color-mix(in srgb, var(--project-accent, var(--accent)) 20%, transparent),
-    var(--shadow);
+  transform: translateY(-3px);
+  border-color: color-mix(in srgb, var(--pa) 35%, var(--line-strong));
+  background: var(--bg-elev-2);
+}
+
+.projectCard:hover::before {
+  height: 6px;
+}
+
+.projectCard:hover::after {
+  opacity: 1;
 }
 
 .projectHeader {
   display: flex;
   flex-direction: column;
-  gap: 0.7rem;
+  gap: 0.9rem;
 }
 
-.statusPill {
-  width: fit-content;
-  padding: 0.38rem 0.62rem;
-  border-radius: 999px;
-  background: color-mix(
-    in srgb,
-    var(--project-accent, var(--accent)) 13%,
-    transparent
-  );
-  color: color-mix(in srgb, var(--project-accent, var(--accent)) 82%, var(--ink));
-  font-size: 0.72rem;
-  text-transform: uppercase;
+.projectCard h3 {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 1.7rem;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  color: var(--ink);
+  font-variation-settings: "opsz" 32;
+}
+
+.projectCard p {
+  color: var(--ink-soft);
+  font-size: 0.95rem;
+  line-height: 1.6;
 }
 
 .pillRow {
@@ -487,65 +552,59 @@
   align-items: center;
 }
 
-.threadPill {
-  padding: 0.32rem 0.6rem;
-  border-radius: 999px;
-  border: 1px dashed
-    color-mix(in srgb, var(--project-accent, var(--accent)) 50%, var(--line));
-  color: var(--ink-soft);
-  font-family: var(--font-mono), "Courier New", monospace;
-  font-size: 0.68rem;
-  letter-spacing: 0.08em;
+.statusPill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.32rem 0.55rem;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
+  color: color-mix(in srgb, var(--pa) 70%, var(--ink));
+  background: color-mix(in srgb, var(--pa) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--pa) 30%, transparent);
 }
 
-.outcome {
-  padding: 1rem 1rem 1rem 0.85rem;
-  border-radius: 1.1rem;
-  border-left: 3px solid
-    color-mix(in srgb, var(--project-accent, var(--accent)) 60%, transparent);
-  background: rgba(239, 231, 219, 0.82);
-}
-
-.tagList {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.6rem;
-}
-
-.tagList li {
-  padding: 0.45rem 0.7rem;
-  border-radius: 999px;
-  background: rgba(255, 250, 243, 0.88);
-  border: 1px solid var(--line);
-  color: var(--ink-soft);
-  font-size: 0.92rem;
+.threadPill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.32rem 0.55rem;
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  border: 1px dashed var(--line-strong);
 }
 
 .metricsList {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem 0.85rem;
+  gap: 0.4rem 1rem;
   padding: 0;
   margin: 0;
   list-style: none;
-  font-family: var(--font-mono), "Courier New", monospace;
-  font-size: 0.78rem;
-  letter-spacing: 0.04em;
-  color: color-mix(in srgb, var(--project-accent, var(--accent)) 78%, var(--ink));
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
+  color: color-mix(in srgb, var(--pa) 60%, var(--ink-soft));
 }
 
 .metricsList li {
   position: relative;
-  padding-right: 0.85rem;
+  padding-right: 1rem;
 }
 
 .metricsList li::after {
-  content: "·";
+  content: "/";
   position: absolute;
   right: 0;
-  color: var(--ink-soft);
+  color: var(--ink-dim);
+  opacity: 0.6;
 }
 
 .metricsList li:last-child {
@@ -556,233 +615,402 @@
   content: "";
 }
 
-.projectLinks {
+.outcome {
+  padding: 0.9rem 1rem 0.9rem 1rem;
+  border-left: 2px solid color-mix(in srgb, var(--pa) 70%, transparent);
+  background: color-mix(in srgb, var(--pa) 5%, var(--bg-warm));
+  font-style: italic;
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: 0.98rem;
+  line-height: 1.5;
+  color: var(--ink);
+  font-variation-settings: "opsz" 18;
+}
+
+.tagList {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.7rem;
+  gap: 0.4rem;
+  padding: 0;
+  list-style: none;
   margin-top: auto;
+}
+
+.tagList li {
+  padding: 0.32rem 0.55rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--ink-soft);
+  background: var(--bg-warm);
+  border: 1px solid var(--line);
+}
+
+.projectLinks,
+.contactLinks,
+.resumeLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.1rem;
+  margin-top: 0.4rem;
+}
+
+.projectLinks a,
+.contactLinks a,
+.resumeLinks a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0;
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink);
+  border-bottom: 1px solid var(--line-strong);
+  transition: color 150ms ease, border-color 150ms ease;
+}
+
+.projectLinks a:hover,
+.contactLinks a:hover,
+.resumeLinks a:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.projectLinks span {
+  color: var(--ink-soft);
+  font-size: 0.9rem;
 }
 
 .sectionCtaRow {
   display: flex;
   justify-content: flex-start;
-  margin-top: 1rem;
+  margin-top: 2rem;
 }
 
-.projectLinks a,
-.contactLinks a {
-  padding: 0 1rem;
-}
-
-.projectLinks span {
-  color: var(--ink-soft);
-  font-size: 0.95rem;
-}
+/* ============================================================
+   Timeline (Experience)
+   ============================================================ */
 
 .timeline {
   display: grid;
-  gap: 0.9rem;
+  gap: 0;
 }
 
 .timelineItem {
   display: grid;
-  grid-template-columns: minmax(140px, 0.34fr) minmax(0, 1fr);
-  gap: 1rem;
-  padding: 1.3rem 0 1.4rem;
+  grid-template-columns: minmax(160px, 0.28fr) minmax(0, 1fr);
+  gap: 2rem;
+  padding: 1.8rem 0;
   border-top: 1px solid var(--line);
+  transition: background 200ms ease, padding 200ms ease;
 }
 
-.timelineMeta,
-.resumeMeta {
+.timelineItem:last-child {
+  border-bottom: 1px solid var(--line);
+}
+
+.timelineItem:hover {
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--accent) 4%, transparent),
+    transparent 30%
+  );
+}
+
+.timelineMeta {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
-  color: var(--ink-soft);
-  font-size: 0.8rem;
+  gap: 0.35rem;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
+  color: var(--ink-dim);
+}
+
+.timelineMeta span:first-child {
+  color: var(--accent);
 }
 
 .timelineContent {
-  display: grid;
-  gap: 0.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.timelineContent h3 {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 1.4rem;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  font-variation-settings: "opsz" 24;
 }
 
 .company {
-  color: var(--accent-strong);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
   font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--accent-warm);
 }
 
-.contactPanel,
-.resumeHeader,
-.resumeSection,
-.projectsHeader,
-.projectPageHeader {
-  border-radius: 1.8rem;
+.timelineContent p:not(.company) {
+  color: var(--ink-soft);
+  line-height: 1.65;
+  font-size: 0.98rem;
+  max-width: 60ch;
 }
+
+/* ============================================================
+   Contact
+   ============================================================ */
 
 .contactPanel {
   display: grid;
-  grid-template-columns: minmax(0, 1.3fr) minmax(220px, 0.7fr);
-  gap: 1rem;
-  align-items: start;
-  padding: 1.6rem;
+  grid-template-columns: minmax(0, 1.4fr) minmax(220px, 0.6fr);
+  gap: 3rem;
+  align-items: end;
+  padding: 3rem 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
 }
 
-.contactLinks,
-.resumeLinks {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
+.contactPanel h2 {
+  margin-bottom: 0.5rem;
 }
 
-.printButton {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 2.8rem;
-  padding: 0 1.15rem;
-  border-radius: 999px;
-  border: 1px solid var(--line);
-  background: rgba(255, 250, 243, 0.82);
-  color: inherit;
-  cursor: pointer;
-  font: inherit;
-  transition:
-    transform 150ms ease,
-    border-color 150ms ease,
-    color 150ms ease;
+.contactText {
+  max-width: 44ch;
+  color: var(--ink-soft);
+  line-height: 1.65;
+  margin-top: 0.5rem;
 }
 
-.printButton:hover {
-  transform: translateY(-1px);
-  border-color: rgba(15, 118, 110, 0.28);
-  color: var(--accent-strong);
-}
+/* ============================================================
+   Footer
+   ============================================================ */
 
 .footer {
   display: flex;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 1rem;
-  max-width: 1120px;
+  max-width: 1240px;
   margin: 0 auto;
-  padding: 0 1.4rem 2rem;
-  color: var(--ink-soft);
-  font-size: 0.95rem;
+  padding: 2rem 1.6rem 3rem;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  border-top: 1px solid var(--line);
+  margin-top: 4rem;
 }
 
 .footerNote a {
-  color: var(--accent-strong);
-  text-decoration: underline;
-  text-decoration-color: color-mix(in srgb, var(--accent) 35%, transparent);
-  text-underline-offset: 3px;
+  color: var(--accent);
+  border-bottom: 1px solid transparent;
+  transition: border-color 150ms ease;
 }
 
 .footerNote a:hover {
-  text-decoration-color: var(--accent-strong);
+  border-color: var(--accent);
 }
+
+/* ============================================================
+   Resume page
+   ============================================================ */
 
 .resumeShell {
   max-width: 980px;
   margin: 0 auto;
-  padding: 2rem 1.4rem 4rem;
+  padding: 3rem 1.6rem 4rem;
 }
 
 .resumeHeader {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
-  padding: 1.6rem;
-  border: 1px solid var(--line);
-  background: var(--surface);
-  box-shadow: var(--shadow);
+  flex-wrap: wrap;
+  gap: 2rem;
+  padding: 0 0 2.5rem;
+  border-bottom: 1px solid var(--line);
 }
 
 .resumeHeader h1 {
-  font-size: clamp(2.2rem, 5vw, 4rem);
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-style: italic;
+  font-variation-settings: "opsz" 144, "SOFT" 100;
+  font-size: clamp(2.6rem, 6vw, 4.6rem);
   line-height: 0.95;
-  letter-spacing: -0.05em;
+  letter-spacing: -0.045em;
+  color: var(--ink);
 }
 
 .resumeLead {
-  max-width: 36rem;
-  margin-top: 0.9rem;
+  max-width: 40rem;
+  margin-top: 1.2rem;
   color: var(--ink-soft);
-  line-height: 1.6;
+  font-size: 1.02rem;
+  line-height: 1.65;
 }
 
 .resumeContent {
   display: grid;
-  gap: 1rem;
+  gap: 0;
   margin-top: 1rem;
 }
 
 .resumeSection {
-  padding: 1.5rem;
-  border: 1px solid var(--line);
-  background: var(--surface);
-  box-shadow: var(--shadow);
+  padding: 2.6rem 0 2.4rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.resumeSection:last-child {
+  border-bottom: 0;
+}
+
+.resumeSection h2 {
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  margin-bottom: 1.6rem;
 }
 
 .resumeStack {
   display: grid;
-  gap: 0.9rem;
-  margin-top: 1rem;
+  gap: 1.6rem;
 }
 
 .resumeCard {
-  padding: 1.2rem;
-  border-radius: 1.3rem;
+  display: grid;
+  gap: 0.5rem;
+  padding: 1.4rem 0;
+  border-top: 1px solid var(--line);
+}
+
+.resumeCard:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.resumeCard h3 {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 1.3rem;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  font-variation-settings: "opsz" 24;
+}
+
+.resumeCard p {
+  color: var(--ink-soft);
+  line-height: 1.65;
+  font-size: 0.98rem;
 }
 
 .resumeRow {
   display: flex;
-  align-items: flex-start;
+  align-items: baseline;
   justify-content: space-between;
   gap: 1rem;
-  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.4rem;
 }
+
+.resumeMeta {
+  display: flex;
+  gap: 0.8rem;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+}
+
+.resumeMeta span:first-child {
+  color: var(--accent);
+}
+
+.printButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.2rem;
+  border: 1px solid var(--line-strong);
+  background: transparent;
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: border-color 150ms ease, color 150ms ease, background 150ms ease;
+}
+
+.printButton:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* ============================================================
+   Projects index page
+   ============================================================ */
 
 .projectsShell,
 .projectPageShell {
-  max-width: 1120px;
+  max-width: 1240px;
   margin: 0 auto;
-  padding: 2rem 1.4rem 4rem;
+  padding: 3rem 1.6rem 4rem;
 }
 
 .projectsHeader,
 .projectPageHeader {
   display: grid;
-  gap: 1rem;
-  padding: 1.6rem;
-  border: 1px solid var(--line);
-  background: var(--surface);
-  box-shadow: var(--shadow);
+  gap: 1.2rem;
+  padding: 0 0 3rem;
+  border-bottom: 1px solid var(--line);
 }
 
 .projectsHeader h1,
 .projectHero h1 {
-  max-width: 12ch;
-  font-size: clamp(2.4rem, 6vw, 5rem);
-  line-height: 0.96;
-  letter-spacing: -0.05em;
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-style: italic;
+  font-variation-settings: "opsz" 144, "SOFT" 100;
+  font-size: clamp(2.8rem, 7vw, 5.6rem);
+  line-height: 0.92;
+  letter-spacing: -0.045em;
+  color: var(--ink);
+  max-width: 16ch;
 }
 
 .projectsList {
   display: grid;
-  gap: 1rem;
-  margin-top: 1rem;
+  gap: 0;
+  margin-top: 0;
 }
 
 .projectsGroups {
   display: grid;
-  gap: 1.6rem;
-  margin-top: 1rem;
+  gap: 3.6rem;
+  margin-top: 2.5rem;
 }
 
 .projectsGroup {
   display: grid;
-  gap: 0.4rem;
+  gap: 0;
 }
 
 .projectsGroupHeading {
@@ -790,364 +1018,551 @@
   align-items: baseline;
   justify-content: space-between;
   gap: 1rem;
-  padding: 0.4rem 0.2rem;
-  border-bottom: 1px solid var(--line);
+  padding: 0 0 1rem;
+  margin-bottom: 0.4rem;
+  border-bottom: 1px solid var(--line-strong);
 }
 
 .projectsGroupHeading h2 {
-  font-family: var(--font-display), "Trebuchet MS", sans-serif;
-  font-size: clamp(1.4rem, 2.4vw, 1.9rem);
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-style: italic;
+  font-size: clamp(1.6rem, 2.8vw, 2.2rem);
   letter-spacing: -0.03em;
+  color: var(--ink);
 }
 
 .projectsGroupHeading span {
-  font-family: var(--font-mono), "Courier New", monospace;
-  font-size: 0.78rem;
-  letter-spacing: 0.08em;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--ink-soft);
+  color: var(--ink-dim);
 }
 
 .projectListCard {
+  --pa: var(--project-accent, var(--accent));
+  position: relative;
   display: grid;
-  grid-template-columns: minmax(180px, 0.35fr) minmax(0, 1fr) auto;
-  gap: 1rem;
-  align-items: center;
+  grid-template-columns: minmax(180px, 0.32fr) minmax(0, 1fr) auto;
+  gap: 2rem;
+  align-items: start;
+  padding: 1.6rem 0;
+  border-top: 1px solid var(--line);
+  transition: background 200ms ease, padding 200ms ease;
 }
 
-.projectListMeta,
-.projectFacts span {
+.projectListCard:hover {
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--pa) 6%, transparent),
+    transparent 40%
+  );
+  padding-left: 0.5rem;
+}
+
+.projectListMeta {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  color: var(--ink-soft);
-  font-family: var(--font-mono), "Courier New", monospace;
-  font-size: 0.8rem;
-  letter-spacing: 0.06em;
+  gap: 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
+  color: var(--ink-dim);
+}
+
+.projectListMeta span:first-child {
+  color: var(--pa);
 }
 
 .projectListBody {
-  display: grid;
-  gap: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
 }
 
-.projectListBody h2,
-.storyCard h2 {
-  font-size: 1.35rem;
-  letter-spacing: -0.03em;
+.projectListBody h2 {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 1.6rem;
+  letter-spacing: -0.025em;
+  color: var(--ink);
+  font-variation-settings: "opsz" 28;
 }
 
-.projectListBody p,
-.storyCard p {
+.projectListBody p {
   color: var(--ink-soft);
   line-height: 1.65;
+  font-size: 0.98rem;
+  max-width: 60ch;
 }
+
+/* ============================================================
+   Project detail page
+   ============================================================ */
 
 .projectHero {
   display: grid;
-  gap: 0.3rem;
+  gap: 1.2rem;
 }
 
 .projectFacts {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 0;
+  margin-top: 1.2rem;
 }
 
-.projectFacts div {
-  display: grid;
-  gap: 0.3rem;
-  padding: 0.9rem 1rem;
-  border: 1px solid
-    color-mix(in srgb, var(--project-accent, var(--accent)) 26%, var(--line));
-  border-radius: 1rem;
-  background: rgba(255, 250, 243, 0.82);
+.projectFacts > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 1rem 1.4rem 1rem 0;
+  margin-right: 1.4rem;
+  border-right: 1px solid var(--line);
+}
+
+.projectFacts > div:last-child {
+  border-right: 0;
+}
+
+.projectFacts span {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
 }
 
 .projectFacts strong {
-  font-size: 1rem;
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 1.05rem;
+  color: var(--ink);
+  letter-spacing: -0.02em;
+  font-variation-settings: "opsz" 16;
 }
 
 .projectStoryGrid {
+  display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  margin-top: 1rem;
+  gap: 2.4rem;
+  margin-top: 3rem;
+}
+
+.storyCard {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.storyCard h2 {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-style: italic;
+  font-size: 1.7rem;
+  letter-spacing: -0.025em;
+  color: var(--ink);
+  font-variation-settings: "opsz" 32;
+}
+
+.storyCard p {
+  color: var(--ink-soft);
+  line-height: 1.7;
+  font-size: 1rem;
 }
 
 .projectQuote {
   position: relative;
-  margin: 1.4rem 0 0;
-  padding: 1.4rem 1.6rem 1.4rem 2.2rem;
-  border-radius: 1.4rem;
-  background: color-mix(
-    in srgb,
-    var(--project-accent, var(--accent)) 8%,
-    rgba(255, 250, 243, 0.85)
+  margin: 2rem 0 0;
+  padding: 1.8rem 2rem 1.8rem 3rem;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--project-accent, var(--accent)) 6%, var(--bg-elev)),
+    var(--bg-elev)
   );
-  border: 1px solid var(--line);
-  font-family: var(--font-display), "Trebuchet MS", sans-serif;
-  font-size: 1.1rem;
+  border-left: 3px solid var(--project-accent, var(--accent));
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 1.25rem;
   line-height: 1.45;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.015em;
   color: var(--ink);
+  font-variation-settings: "opsz" 24;
 }
 
 .projectQuote::before {
   content: "\201C";
   position: absolute;
-  top: 0.4rem;
-  left: 0.9rem;
-  font-size: 2.4rem;
+  top: 0.6rem;
+  left: 1rem;
+  font-size: 3.2rem;
   line-height: 1;
-  color: color-mix(in srgb, var(--project-accent, var(--accent)) 60%, transparent);
+  color: color-mix(in srgb, var(--project-accent, var(--accent)) 70%, transparent);
 }
 
 .projectQuote cite {
   display: block;
-  margin-top: 0.6rem;
-  font-family: var(--font-mono), "Courier New", monospace;
-  font-size: 0.72rem;
+  margin-top: 0.8rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
   font-style: normal;
-  letter-spacing: 0.08em;
+  font-weight: 500;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--ink-soft);
-}
-
-.storyCard {
-  display: grid;
-  gap: 0.9rem;
+  color: var(--ink-dim);
 }
 
 .projectHeaderLinks {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.7rem;
-  margin-top: 0.8rem;
+  gap: 1.2rem;
+  margin-top: 1rem;
 }
 
 .projectHeaderLinks a {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  min-height: 2.6rem;
-  padding: 0 1rem;
-  border-radius: 999px;
-  border: 1px solid var(--line);
-  background: rgba(255, 250, 243, 0.82);
+  gap: 0.45rem;
+  padding: 0.5rem 0;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink);
+  border-bottom: 1px solid var(--line-strong);
+  transition: color 150ms ease, border-color 150ms ease;
 }
 
 .projectHeaderLinks a:hover {
-  border-color: color-mix(
-    in srgb,
-    var(--project-accent, var(--accent)) 38%,
-    var(--line)
-  );
-  color: var(--accent-strong);
+  color: var(--project-accent, var(--accent));
+  border-color: var(--project-accent, var(--accent));
 }
 
 .relatedSection {
-  margin-top: 1.5rem;
-  padding: 1.5rem;
-  border: 1px solid var(--line);
-  border-radius: 1.8rem;
-  background: var(--surface);
-  box-shadow: var(--shadow);
+  margin-top: 4rem;
+  padding-top: 2.5rem;
+  border-top: 1px solid var(--line);
 }
 
 .relatedGrid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
-  margin-top: 1rem;
+  gap: 1.2rem;
+  margin-top: 1.5rem;
 }
 
 .relatedCard {
+  --pa: var(--project-accent, var(--accent));
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
-  padding: 1.1rem;
+  gap: 0.7rem;
+  padding: 1.3rem 1.2rem 1.2rem;
+  background: var(--bg-elev);
   border: 1px solid var(--line);
-  border-radius: 1.2rem;
-  background: rgba(255, 250, 243, 0.7);
   overflow: hidden;
-  transition:
-    transform 200ms ease,
-    border-color 200ms ease,
-    box-shadow 200ms ease;
+  transition: transform 200ms ease, border-color 200ms ease, background 200ms ease;
 }
 
 .relatedCard::before {
   content: "";
   position: absolute;
-  inset: 0 auto 0 0;
-  width: 3px;
-  background: color-mix(
-    in srgb,
-    var(--project-accent, var(--accent)) 70%,
-    transparent
-  );
-  opacity: 0.85;
+  inset: 0 0 auto 0;
+  height: 3px;
+  background: var(--pa);
 }
 
 .relatedCard:hover {
   transform: translateY(-2px);
-  border-color: color-mix(
-    in srgb,
-    var(--project-accent, var(--accent)) 32%,
-    var(--line)
-  );
-  box-shadow:
-    0 16px 32px
-      color-mix(in srgb, var(--project-accent, var(--accent)) 14%, transparent),
-    var(--shadow);
+  border-color: color-mix(in srgb, var(--pa) 30%, var(--line-strong));
+  background: var(--bg-elev-2);
 }
 
 .relatedCard h3 {
-  font-size: 1.05rem;
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 1.15rem;
   letter-spacing: -0.02em;
+  color: var(--ink);
+  font-variation-settings: "opsz" 18;
 }
 
 .relatedCard p {
   color: var(--ink-soft);
   line-height: 1.55;
-  font-size: 0.92rem;
+  font-size: 0.9rem;
 }
 
-@media (max-width: 920px) {
-  .relatedGrid {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 920px) {
-  .hero,
-  .dualGrid,
-  .projectGrid,
-  .contactPanel,
-  .principlesGrid,
-  .projectStoryGrid {
-    grid-template-columns: 1fr;
-  }
-
-  .projectGrid {
-    gap: 1rem;
-  }
-
-  .projectListCard {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 720px) {
-  .header {
-    padding: 1rem 1rem 0;
-  }
-
-  .navWrap,
-  .resumeHeader,
-  .resumeRow,
-  .timelineItem {
-    grid-template-columns: 1fr;
-  }
-
-  .navWrap,
-  .resumeHeader,
-  .resumeRow {
-    display: grid;
-  }
-
-  .nav {
-    flex-wrap: wrap;
-    gap: 0.8rem;
-  }
-
-  .main,
-  .resumeShell,
-  .projectsShell,
-  .projectPageShell {
-    padding-left: 1rem;
-    padding-right: 1rem;
-  }
-
-  .hero {
-    padding-top: 2.2rem;
-  }
-
-  .heroCopy,
-  .heroPanel,
-  .surfaceCard,
-  .principleCard,
-  .projectCard,
-  .projectListCard,
-  .storyCard,
-  .contactPanel,
-  .resumeSection,
-  .projectsHeader,
-  .projectPageHeader {
-    border-radius: 1.4rem;
-  }
-
-  .timelineItem {
-    display: grid;
-    gap: 0.7rem;
-  }
-
-  .footer {
-    flex-direction: column;
-    padding-left: 1rem;
-    padding-right: 1rem;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .projectCard,
-  .projectListCard {
-    transition: none;
-  }
-
-  .projectCard:hover,
-  .projectListCard:hover {
-    transform: none;
-  }
-}
+/* ============================================================
+   Now page
+   ============================================================ */
 
 .nowList {
   list-style: none;
-  margin: 1.5rem 0 0;
+  margin: 2.5rem 0 0;
   padding: 0;
   display: grid;
-  gap: 1rem;
+  gap: 0;
 }
 
 .nowItem {
   position: relative;
-  padding: 1.3rem 1.5rem 1.3rem 1.8rem;
-  border: 1px solid var(--line);
-  border-radius: 1.2rem;
-  background: rgba(255, 250, 243, 0.7);
-  overflow: hidden;
+  display: grid;
+  grid-template-columns: minmax(140px, 0.22fr) minmax(0, 1fr);
+  gap: 2rem;
+  padding: 1.8rem 0;
+  border-top: 1px solid var(--line);
+  transition: background 200ms ease, padding 200ms ease;
+}
+
+.nowItem:last-child {
+  border-bottom: 1px solid var(--line);
 }
 
 .nowItem::before {
-  content: "";
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: 3px;
-  background: color-mix(in srgb, var(--accent) 70%, transparent);
+  content: counter(now-index, decimal-leading-zero);
+  counter-increment: now-index;
+  grid-column: 1;
+  grid-row: 1 / span 2;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  color: var(--accent);
+  padding-top: 0.4rem;
+}
+
+.nowItem > * {
+  grid-column: 2;
+}
+
+.nowList {
+  counter-reset: now-index;
+}
+
+.nowItem:hover {
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--accent) 5%, transparent),
+    transparent 35%
+  );
+  padding-left: 0.5rem;
 }
 
 .nowItem h2 {
-  margin: 0 0 0.4rem;
-  font-size: 1.1rem;
-  letter-spacing: -0.01em;
+  margin: 0 0 0.6rem;
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 1.45rem;
+  letter-spacing: -0.025em;
+  color: var(--ink);
+  font-variation-settings: "opsz" 24;
 }
 
 .nowItem p {
   margin: 0;
   color: var(--ink-soft);
-  line-height: 1.55;
+  line-height: 1.7;
+  font-size: 1rem;
+  max-width: 60ch;
 }
+
+/* ============================================================
+   Other surfaces (principles, dual, etc.)
+   ============================================================ */
+
+.dualGrid,
+.principlesGrid {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.dualGrid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.principlesGrid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.surfaceCard,
+.principleCard,
+.storyCard {
+  background: transparent;
+}
+
+.surfaceCard,
+.principleCard {
+  padding: 1.4rem 1.4rem 1.4rem 1.4rem;
+  border: 1px solid var(--line);
+  background: var(--bg-elev);
+  transition: background 200ms ease, border-color 200ms ease;
+}
+
+.surfaceCard:hover,
+.principleCard:hover {
+  background: var(--bg-elev-2);
+  border-color: var(--line-strong);
+}
+
+.surfaceCard h3,
+.principleCard h3 {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 1.2rem;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.7rem;
+  color: var(--ink);
+  font-variation-settings: "opsz" 18;
+}
+
+.surfaceCard p,
+.principleCard p {
+  color: var(--ink-soft);
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+
+.bulletList {
+  display: grid;
+  gap: 0.7rem;
+  padding: 0;
+  list-style: none;
+  margin-top: 0.6rem;
+}
+
+.bulletList li {
+  position: relative;
+  padding-left: 1.2rem;
+  color: var(--ink-soft);
+  line-height: 1.65;
+  font-size: 0.95rem;
+}
+
+.bulletList li::before {
+  content: "▸";
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: var(--accent);
+  font-size: 0.8rem;
+}
+
+/* ============================================================
+   Responsive
+   ============================================================ */
+
+@media (max-width: 980px) {
+  .hero {
+    grid-template-columns: 1fr;
+    gap: 2.4rem;
+    padding: 3rem 0;
+  }
+
+  .projectGrid,
+  .relatedGrid,
+  .projectStoryGrid,
+  .dualGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .principlesGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .contactPanel {
+    grid-template-columns: 1fr;
+    align-items: start;
+    gap: 1.6rem;
+  }
+
+  .projectListCard {
+    grid-template-columns: 1fr;
+    gap: 0.8rem;
+  }
+
+  .timelineItem {
+    grid-template-columns: 1fr;
+    gap: 0.6rem;
+  }
+
+  .nowItem {
+    grid-template-columns: 1fr;
+    gap: 0.6rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .header {
+    padding-bottom: 0.4rem;
+  }
+
+  .marquee {
+    padding: 0.45rem 1rem;
+    font-size: 0.62rem;
+    gap: 0.6rem;
+  }
+
+  .navWrap,
+  .main,
+  .resumeShell,
+  .projectsShell,
+  .projectPageShell,
+  .footer {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .nav {
+    gap: 1rem;
+  }
+
+  .heroCopy h1 {
+    font-size: clamp(2.6rem, 11vw, 4rem);
+  }
+
+  .resumeHeader {
+    flex-direction: column;
+  }
+
+  .footer {
+    flex-direction: column;
+  }
+
+  .principlesGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .projectCard,
+  .relatedCard,
+  .timelineItem,
+  .projectListCard,
+  .nowItem {
+    transition: none;
+  }
+
+  .projectCard:hover,
+  .relatedCard:hover {
+    transform: none;
+  }
+
+  .statusDot {
+    animation: none;
+  }
+}
+
+/* ============================================================
+   Print (resume)
+   ============================================================ */
 
 @media print {
   .resumeShell {
@@ -1159,8 +1574,6 @@
   .resumeSection,
   .resumeCard {
     border: 0;
-    border-radius: 0;
-    box-shadow: none;
     padding: 0;
     background: transparent;
   }
@@ -1205,9 +1618,5 @@
   .resumeLead,
   .resumeCard p {
     font-size: 10.5pt;
-  }
-
-  .eyebrow {
-    margin-bottom: 0.3rem;
   }
 }

--- a/src/styles/Portfolio.module.css
+++ b/src/styles/Portfolio.module.css
@@ -1112,6 +1112,43 @@
   }
 }
 
+.nowList {
+  list-style: none;
+  margin: 1.5rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.nowItem {
+  position: relative;
+  padding: 1.3rem 1.5rem 1.3rem 1.8rem;
+  border: 1px solid var(--line);
+  border-radius: 1.2rem;
+  background: rgba(255, 250, 243, 0.7);
+  overflow: hidden;
+}
+
+.nowItem::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: color-mix(in srgb, var(--accent) 70%, transparent);
+}
+
+.nowItem h2 {
+  margin: 0 0 0.4rem;
+  font-size: 1.1rem;
+  letter-spacing: -0.01em;
+}
+
+.nowItem p {
+  margin: 0;
+  color: var(--ink-soft);
+  line-height: 1.55;
+}
+
 @media print {
   .resumeShell {
     max-width: none;

--- a/src/styles/Portfolio.module.css
+++ b/src/styles/Portfolio.module.css
@@ -571,6 +571,30 @@
   gap: 0.75rem;
 }
 
+.printButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.8rem;
+  padding: 0 1.15rem;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: rgba(255, 250, 243, 0.82);
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  transition:
+    transform 150ms ease,
+    border-color 150ms ease,
+    color 150ms ease;
+}
+
+.printButton:hover {
+  transform: translateY(-1px);
+  border-color: rgba(15, 118, 110, 0.28);
+  color: var(--accent-strong);
+}
+
 .footer {
   display: flex;
   justify-content: space-between;
@@ -869,5 +893,68 @@
   .projectCard:hover,
   .projectListCard:hover {
     transform: none;
+  }
+}
+
+@media print {
+  .resumeShell {
+    max-width: none;
+    padding: 0;
+  }
+
+  .resumeHeader,
+  .resumeSection,
+  .resumeCard {
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+    padding: 0;
+    background: transparent;
+  }
+
+  .resumeHeader {
+    border-bottom: 1px solid var(--line);
+    padding-bottom: 0.6rem;
+    margin-bottom: 1rem;
+    page-break-after: avoid;
+  }
+
+  .resumeContent {
+    gap: 0.8rem;
+    margin-top: 0.6rem;
+  }
+
+  .resumeSection {
+    padding: 0.4rem 0;
+    border-top: 1px solid var(--line);
+    page-break-inside: avoid;
+  }
+
+  .resumeStack {
+    gap: 0.6rem;
+    margin-top: 0.4rem;
+  }
+
+  .resumeCard {
+    padding: 0.2rem 0;
+    page-break-inside: avoid;
+  }
+
+  .resumeHeader h1 {
+    font-size: 22pt;
+  }
+
+  .resumeSection h2 {
+    font-size: 13pt;
+    margin: 0;
+  }
+
+  .resumeLead,
+  .resumeCard p {
+    font-size: 10.5pt;
+  }
+
+  .eyebrow {
+    margin-bottom: 0.3rem;
   }
 }

--- a/src/styles/Portfolio.module.css
+++ b/src/styles/Portfolio.module.css
@@ -432,6 +432,40 @@
   font-size: 0.92rem;
 }
 
+.metricsList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.85rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  font-family: var(--font-mono), "Courier New", monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  color: color-mix(in srgb, var(--project-accent, var(--accent)) 78%, var(--ink));
+  text-transform: uppercase;
+}
+
+.metricsList li {
+  position: relative;
+  padding-right: 0.85rem;
+}
+
+.metricsList li::after {
+  content: "·";
+  position: absolute;
+  right: 0;
+  color: var(--ink-soft);
+}
+
+.metricsList li:last-child {
+  padding-right: 0;
+}
+
+.metricsList li:last-child::after {
+  content: "";
+}
+
 .projectLinks {
   display: flex;
   flex-wrap: wrap;

--- a/src/styles/Portfolio.module.css
+++ b/src/styles/Portfolio.module.css
@@ -371,6 +371,34 @@
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
+.featuredGroup {
+  display: grid;
+  gap: 0.7rem;
+  margin-top: 1.6rem;
+}
+
+.featuredGroup:first-of-type {
+  margin-top: 0.4rem;
+}
+
+.featuredGroupLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-family: var(--font-mono), "Courier New", monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+.featuredGroupLabel::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--line);
+}
+
 .projectCard {
   display: flex;
   flex-direction: column;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,18 +1,30 @@
 :root {
-  color-scheme: light;
-  --font-display: "Space Grotesk";
-  --font-mono: "IBM Plex Mono";
-  --bg: #f4efe7;
-  --surface: rgba(255, 252, 246, 0.84);
-  --surface-strong: #fffaf3;
-  --surface-muted: #efe7db;
-  --ink: #1f1d1a;
-  --ink-soft: #5b534a;
-  --line: rgba(40, 32, 22, 0.12);
-  --accent: #0f766e;
-  --accent-strong: #0b5f58;
-  --accent-warm: #c96b3b;
-  --shadow: 0 20px 60px rgba(72, 52, 33, 0.08);
+  color-scheme: dark;
+  --font-display: "Fraunces";
+  --font-mono: "JetBrains Mono";
+  --font-body: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Inter",
+    "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+
+  --bg: #0e0c0a;
+  --bg-elev: #181410;
+  --bg-elev-2: #221c16;
+  --bg-warm: #2a2118;
+
+  --ink: #f1ebde;
+  --ink-soft: #b3a99a;
+  --ink-dim: #75695a;
+
+  --line: rgba(241, 235, 222, 0.08);
+  --line-strong: rgba(241, 235, 222, 0.18);
+  --line-hot: rgba(255, 91, 31, 0.5);
+
+  --accent: #ff5b1f;
+  --accent-soft: #ff7a48;
+  --accent-warm: #f5b048;
+  --accent-cool: #6fd4b8;
+
+  --shadow: 0 30px 80px rgba(0, 0, 0, 0.4);
+  --shadow-sm: 0 8px 24px rgba(0, 0, 0, 0.3);
 }
 
 * {
@@ -26,12 +38,51 @@ html {
 body {
   margin: 0;
   min-width: 320px;
-  background:
-    radial-gradient(circle at top left, rgba(201, 107, 59, 0.12), transparent 26rem),
-    radial-gradient(circle at top right, rgba(15, 118, 110, 0.15), transparent 30rem),
-    linear-gradient(180deg, #f8f3ec 0%, #f4efe7 48%, #efe6d8 100%);
+  background: var(--bg);
   color: var(--ink);
-  font-family: var(--font-display), "Trebuchet MS", sans-serif;
+  font-family: var(--font-body);
+  font-size: 16px;
+  line-height: 1.55;
+  font-feature-settings: "ss01", "cv11";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  background:
+    radial-gradient(
+      ellipse 80% 50% at 15% 0%,
+      rgba(255, 91, 31, 0.18),
+      transparent 60%
+    ),
+    radial-gradient(
+      ellipse 60% 40% at 90% 10%,
+      rgba(245, 176, 72, 0.1),
+      transparent 60%
+    ),
+    radial-gradient(
+      ellipse 80% 50% at 50% 100%,
+      rgba(111, 212, 184, 0.06),
+      transparent 60%
+    ),
+    var(--bg);
+  pointer-events: none;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 1   0 0 0 0 1   0 0 0 0 1   0 0 0 0.16 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+  opacity: 0.35;
+  mix-blend-mode: overlay;
+  pointer-events: none;
 }
 
 a {
@@ -40,9 +91,14 @@ a {
 }
 
 :where(a, button, [tabindex]):focus-visible {
-  outline: 2px solid var(--accent-strong);
+  outline: 2px solid var(--accent);
   outline-offset: 3px;
-  border-radius: 4px;
+  border-radius: 2px;
+}
+
+::selection {
+  background: var(--accent);
+  color: var(--bg);
 }
 
 .skip-link {
@@ -51,10 +107,13 @@ a {
   top: 0;
   transform: translateY(-200%);
   padding: 0.6rem 1rem;
-  background: var(--ink);
-  color: #fffaf3;
-  border-radius: 0 0 0.6rem 0.6rem;
-  font-weight: 600;
+  background: var(--accent);
+  color: var(--bg);
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
   z-index: 100;
   transition: transform 150ms ease;
 }
@@ -75,7 +134,13 @@ h2,
 h3,
 h4,
 h5,
-h6,
+h6 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 500;
+  letter-spacing: -0.02em;
+}
+
 p,
 ul {
   margin: 0;
@@ -88,17 +153,21 @@ img {
 
 @media print {
   :root {
+    color-scheme: light;
     --bg: #ffffff;
-    --surface: #ffffff;
-    --surface-strong: #ffffff;
-    --surface-muted: #ffffff;
+    --bg-elev: #ffffff;
+    --bg-elev-2: #ffffff;
+    --bg-warm: #ffffff;
     --ink: #111111;
     --ink-soft: #333333;
+    --ink-dim: #555555;
     --line: rgba(0, 0, 0, 0.16);
+    --line-strong: rgba(0, 0, 0, 0.28);
     --accent: #111111;
-    --accent-strong: #000000;
-    --accent-warm: #444444;
+    --accent-soft: #333333;
+    --accent-warm: #333333;
     --shadow: none;
+    --shadow-sm: none;
   }
 
   html {
@@ -110,6 +179,11 @@ img {
     color: #111111;
     font-size: 10.5pt;
     line-height: 1.4;
+  }
+
+  body::before,
+  body::after {
+    display: none !important;
   }
 
   a {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -61,3 +61,49 @@ img {
   max-width: 100%;
   display: block;
 }
+
+@media print {
+  :root {
+    --bg: #ffffff;
+    --surface: #ffffff;
+    --surface-strong: #ffffff;
+    --surface-muted: #ffffff;
+    --ink: #111111;
+    --ink-soft: #333333;
+    --line: rgba(0, 0, 0, 0.16);
+    --accent: #111111;
+    --accent-strong: #000000;
+    --accent-warm: #444444;
+    --shadow: none;
+  }
+
+  html {
+    scroll-behavior: auto;
+  }
+
+  body {
+    background: #ffffff !important;
+    color: #111111;
+    font-size: 10.5pt;
+    line-height: 1.4;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: underline;
+  }
+
+  a[href^="http"]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.85em;
+    color: #555;
+    word-break: break-all;
+  }
+
+  .print-hide,
+  nav,
+  header [data-print-hide],
+  [data-print-hide] {
+    display: none !important;
+  }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -39,6 +39,30 @@ a {
   text-decoration: none;
 }
 
+:where(a, button, [tabindex]):focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
+.skip-link {
+  position: absolute;
+  left: 1rem;
+  top: 0;
+  transform: translateY(-200%);
+  padding: 0.6rem 1rem;
+  background: var(--ink);
+  color: #fffaf3;
+  border-radius: 0 0 0.6rem 0.6rem;
+  font-weight: 600;
+  z-index: 100;
+  transition: transform 150ms ease;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
 button,
 input,
 textarea,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -131,3 +131,14 @@ img {
     display: none !important;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,8 @@ export interface Project {
   metrics?: string[];
   /** Optional thematic grouping (e.g. "Agent tooling", "Music tooling"). */
   thread?: string;
+  /** Pull-quote from the project itself (often from its README). */
+  quote?: string;
   links: ActionLink[];
   featured: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export interface Project {
   build: string;
   impact: string;
   stack: string[];
+  metrics?: string[];
   links: ActionLink[];
   featured: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,8 @@ export interface Project {
   impact: string;
   stack: string[];
   metrics?: string[];
+  /** Optional thematic grouping (e.g. "Agent tooling", "Music tooling"). */
+  thread?: string;
   links: ActionLink[];
   featured: boolean;
 }

--- a/tests/e2e/portfolio.spec.ts
+++ b/tests/e2e/portfolio.spec.ts
@@ -13,10 +13,11 @@ test.describe("homepage", () => {
     ).toBeVisible();
 
     for (const name of [
-      "Portfolio Refresh",
       "Phren",
+      "Halo Explorer",
       "OGrid",
       "m4l-builder",
+      "LiveMCP",
       "Intranet ERP",
     ]) {
       await expect(
@@ -48,10 +49,10 @@ test.describe("projects", () => {
     ).toBeVisible();
 
     const viewLinks = page.getByRole("link", { name: "View project" });
-    await expect(viewLinks).toHaveCount(7);
+    await expect(viewLinks).toHaveCount(9);
 
     await viewLinks.first().click();
-    await expect(page).toHaveURL(/\/projects\/portfolio-refresh$/);
+    await expect(page).toHaveURL(/\/projects\/phren$/);
   });
 
   test("renders a detail page from a direct deep link", async ({ page }) => {


### PR DESCRIPTION
## Summary

- **Visual redesign**: dark warm palette (#0e0c0a + hot-orange #ff5b1f accent), Fraunces italic display, JetBrains Mono meta, marquee status strip at the top of the home page, poster-style project cards with full-bleed accent stripes per project.
- **Content restoration**: pulls back per-company detail from the 2023 resume that was watered down in the March 2026 refresh — Maryland retrofit work at Matrix Energy, UCSD Music Video Game in Processing, Dell campus rep at UCSC, VMware at GSPA, December 2011 grad date.
- **New material**: Qualus role with actual scope (DBMS for client portfolios, CRM → APIs → Power BI / Tableau in Node + React + Angular). ADM tenure expanded to lead with breadth (Intranet on PG+Rails, EMV on MongoDB, Equipment Tracker on PG+Node, R Server + Shiny data-science infra, SOC 2 fleet) instead of just the ERP. Music thread says the quiet part — produce electronic music in Ableton, tooling came from waiting for it to exist.
- **New projects**: Intrapath (React + Bun rewrite of the Intranet ERP) as a featured Currently-building entry next to Phren. EMV and Equipment Tracker added as Legacy case studies.
- **Location**: Los Angeles everywhere — site copy, JSON-LD person schema, OG meta, web manifest, Qualus role.

## Test plan

- [ ] `bun run typecheck` is clean
- [ ] `bun run build` produces dist/
- [ ] Home page renders the marquee strip and Intrapath in the Currently-building grid
- [ ] /now lists 4 items in the new order with the updated bodies
- [ ] /resume shows Qualus → ADM (expanded) → GSPA → Matrix Energy → UCSD TIES → Dell
- [ ] /projects index shows EMV and Equipment Tracker under Legacy case study
- [ ] /projects/intrapath detail page renders Overview / Work / Result / Stack
- [ ] No `Sacramento` references remain in copy, schema, OG meta, or manifest

## Note

The old `ala.arab@admenergy.com` work email was scrubbed from git history across all branches in a separate operation earlier today (force-pushed `main`, this branch, and two stale claude/* branches). Commit hashes on `main` changed as a result. That rewrite is not part of this PR's diff — it's already on origin. If you have local clones elsewhere, re-clone or `git fetch && git reset --hard origin/<branch>` to sync.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U591tDozVXeHDMwiF98uwH)_